### PR TITLE
Migrate to new PyPI website

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,15 +6,15 @@ Bandit
     :alt: Bandit team and repository tags
 
 .. image:: https://img.shields.io/pypi/v/bandit.svg
-    :target: https://pypi.python.org/pypi/bandit/
+    :target: https://pypi.org/project/bandit/
     :alt: Latest Version
 
 .. image:: https://img.shields.io/pypi/pyversions/bandit.svg
-    :target: https://pypi.python.org/pypi/bandit/
+    :target: https://pypi.org/project/bandit/
     :alt: Python Versions
 
 .. image:: https://img.shields.io/pypi/format/bandit.svg
-    :target: https://pypi.python.org/pypi/bandit/
+    :target: https://pypi.org/project/bandit/
     :alt: Format
 
 .. image:: https://img.shields.io/badge/license-Apache%202-blue.svg

--- a/bandit/blacklists/calls.py
+++ b/bandit/blacklists/calls.py
@@ -216,7 +216,7 @@ B313 - B320: XML
 ----------------
 
 Most of this is based off of Christian Heimes' work on defusedxml:
-https://pypi.python.org/pypi/defusedxml/#defusedxml-sax
+https://pypi.org/project/defusedxml/#defusedxml-sax
 
 Using various XLM methods to parse untrusted XML data is known to be vulnerable
 to XML attacks. Methods should be replaced with their defusedxml equivalents.
@@ -442,7 +442,7 @@ def gen_blacklist():
         ))
 
     # Most of this is based off of Christian Heimes' work on defusedxml:
-    #   https://pypi.python.org/pypi/defusedxml/#defusedxml-sax
+    #   https://pypi.org/project/defusedxml/#defusedxml-sax
 
     xml_msg = ('Using {name} to parse untrusted XML data is known to be '
                'vulnerable to XML attacks. Replace {name} with its '

--- a/bandit/blacklists/imports.py
+++ b/bandit/blacklists/imports.py
@@ -24,7 +24,7 @@ possible security implications. The following blacklist tests are run against
 any import statements or calls encountered in the scanned code base.
 
 Note that the XML rules listed here are mostly based off of Christian Heimes'
-work on defusedxml: https://pypi.python.org/pypi/defusedxml
+work on defusedxml: https://pypi.org/project/defusedxml/
 
 B401: import_telnetlib
 ----------------------
@@ -244,7 +244,7 @@ def gen_blacklist():
         ))
 
     # Most of this is based off of Christian Heimes' work on defusedxml:
-    #   https://pypi.python.org/pypi/defusedxml/#defusedxml-sax
+    #   https://pypi.org/project/defusedxml/#defusedxml-sax
 
     xml_msg = ('Using {name} to parse untrusted XML data is known to be '
                'vulnerable to XML attacks. Replace {name} with the equivalent '


### PR DESCRIPTION
According to [1], the PyPI website of pypi.python.org has changed
to https://pypi.org. This patch updates all references to the legacy
site.

[1] https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html

Signed-off-by: Eric Brown <browne@vmware.com>