### PR TITLE
Create an issue template for the project

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,15 @@
+### Summary 
+
+### Steps to reproduce the behavior
+
+### Bandit version
+<!--- Paste the output from "bandit --version" between quotes below -->
+```
+
+```
+
+### Operating system / Environment
+
+### Expected behavior
+
+### Actual behavior

--- a/bandit/cli/main.py
+++ b/bandit/cli/main.py
@@ -245,10 +245,13 @@ def main():
         '--ini', dest='ini_path', action='store', default=None,
         help='path to a .bandit file that supplies command line arguments'
     )
+    python_ver = sys.version.replace('\n', '')
     parser.add_argument(
         '--version', action='version',
-        version='%(prog)s {version}'.format(version=bandit.__version__)
+        version='%(prog)s {version}\n  python version = {python}'.format(
+            version=bandit.__version__, python=python_ver)
     )
+
     parser.set_defaults(debug=False)
     parser.set_defaults(verbose=False)
     parser.set_defaults(ignore_nosec=False)


### PR DESCRIPTION
This patch adds a template for Issues opened against the Bandit
project. That way, minimum information is present to debug the
problem.

Signed-off-by: Eric Brown <browne@vmware.com>