### PR TITLE
Show support for Python 3.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,8 +46,8 @@ Create a virtual environment (optional)::
 Install Bandit::
 
     pip install bandit
-    # Or if you're working with a Python 3.5 project
-    pip3.5 install bandit
+    # Or if you're working with a Python 3 project
+    pip3 install bandit
 
 Run Bandit::
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifier =
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
     Topic :: Security
 
 [entry_points]


### PR DESCRIPTION
Now that Travis CI is testing Bandit on Python 3.6, the metadata
classifier of setup.cfg should declare this.

Signed-off-by: Eric Brown <browne@vmware.com>