### PR TITLE
Add a build status badge to the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 Bandit
 ======
 
+.. image:: https://travis-ci.org/PyCQA/bandit.svg?branch=master
+    :target: https://travis-ci.org/PyCQA/bandit/
+    :alt: Build Status
+
 .. image:: https://img.shields.io/pypi/v/bandit.svg
     :target: https://pypi.org/project/bandit/
     :alt: Latest Version


### PR DESCRIPTION
This includes a pretty icon badge to the README showing the current
build status for bandit on brach master from Travis CI.

Signed-off-by: Eric Brown <browne@vmware.com>