### PR TITLE
Update the doc links, remove openstack

### DIFF
--- a/bandit/core/docs_utils.py
+++ b/bandit/core/docs_utils.py
@@ -15,7 +15,7 @@
 # under the License.
 
 # where our docs are hosted
-BASE_URL = 'https://docs.openstack.org/bandit/latest/'
+BASE_URL = 'https://bandit.readthedocs.io/en/latest/'
 
 
 def get_url(bid):

--- a/bandit/formatters/html.py
+++ b/bandit/formatters/html.py
@@ -125,9 +125,9 @@ This formatter outputs the issues as HTML.
         <b>Confidence: </b>HIGH<br>
         <b>File: </b><a href="examples/yaml_load.py"
         target="_blank">examples/yaml_load.py</a> <br>
-        <b>More info: </b><a href="https://docs.openstack.org/bandit/latest/
+        <b>More info: </b><a href="https://bandit.readthedocs.io/en/latest/
         plugins/yaml_load.html" target="_blank">
-        https://docs.openstack.org/bandit/latest/plugins/yaml_load.html</a>
+        https://bandit.readthedocs.io/en/latest/plugins/yaml_load.html</a>
         <br>
 
     <div class="code">

--- a/bandit/formatters/json.py
+++ b/bandit/formatters/json.py
@@ -65,7 +65,7 @@ This formatter outputs the issues in JSON.
           "line_range": [
             5
           ],
-          "more_info": "https://docs.openstack.org/bandit/latest/",
+          "more_info": "https://bandit.readthedocs.io/en/latest/",
           "test_name": "blacklist_calls",
           "test_id": "B301"
         }

--- a/bandit/formatters/yaml.py
+++ b/bandit/formatters/yaml.py
@@ -60,7 +60,7 @@ This formatter outputs the issues in a yaml format.
       line_number: 6
       line_range:
       - 6
-      more_info: https://docs.openstack.org/bandit/latest/
+      more_info: https://bandit.readthedocs.io/en/latest/
       test_id: B506
       test_name: yaml_load
 


### PR DESCRIPTION
This change updates the documentation links to no longer point to
the openstack docs URL, and instead point to the readthedocs URL.
   https://bandit.readthedocs.io/en/latest/