### PR TITLE
Use bandit.readthedocs.io in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ description-file =
     README.rst
 author = PyCQA
 author-email = code-quality@python.org
-home-page = http://meta.pycqa.org/en/latest/
+home-page = https://bandit.readthedocs.io/en/latest/
 classifier =
     Environment :: Console
     Intended Audience :: Information Technology


### PR DESCRIPTION
Bandit should reference bandit.readthedocs.io for the home-page
instead of a main PyCQA link. That way those seeing Bandit on PyPI
will be properly navigated to the Bandit documentation.

Signed-off-by: Eric Brown <browne@vmware.com>