### PR TITLE
Add missing documentation link for B703

### DIFF
--- a/doc/source/plugins/b703_django_mark_safe.rst
+++ b/doc/source/plugins/b703_django_mark_safe.rst
@@ -1,0 +1,5 @@
+----------------------
+B703: django_mark_safe
+----------------------
+
+.. automodule:: bandit.plugins.django_mark_safe


### PR DESCRIPTION
PR #295 added a new plugin to check for django XSS, but forgot
a link to the plugin documentation. This patch adds just that.