### PR TITLE
Add development status classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ author = PyCQA
 author-email = code-quality@python.org
 home-page = https://bandit.readthedocs.io/en/latest/
 classifier =
+    Development Status :: 5 - Production/Stable
     Environment :: Console
     Intended Audience :: Information Technology
     Intended Audience :: System Administrators


### PR DESCRIPTION
The development status classifier denotes the development status
of the project. Bandit should be considered a mature stable project
by now.

Fixes Issue #320