### PR TITLE
Enable travis to run pylint and pep8 tox env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,20 @@
 language: python
+
 cache: pip
+
 sudo: false
+
 install:
   - pip install tox
+
 script: tox
+
 matrix:
   include:
+    - python: 2.7
+      env: TOXENV=pylint
+    - python: 2.7
+      env: TOXENV=pep8
     - python: 2.7
       env: TOXENV=py27
     - python: 3.5
@@ -22,4 +31,4 @@ notifications:
     channels:
       - "irc.freenode.org##python-code-quality"
     use_notice: true
-skip_join: true
+    skip_join: true


### PR DESCRIPTION
Currently Travis-CI is only running tox with venv for py27,py35,py36,
and pypy. But the venv for pylint and pep8 are defined in tox and
should be run also.