### PR TITLE
add os.tempnam() / os.tmpnam() to blacklist

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,6 +211,7 @@ Usage::
       B322  input
       B323  unverified_context
       B324  hashlib_new_insecure_functions
+      B325  tempnam
       B401  import_telnetlib
       B402  import_ftplib
       B403  import_pickle

--- a/bandit/blacklists/calls.py
+++ b/bandit/blacklists/calls.py
@@ -558,12 +558,12 @@ def gen_blacklist():
         'or perform hostname checks.'
         ))
 
-    # skipped B324 due to use in bandit/plugins/hashlib_new_insecure_functions.py
+    # skipped B324 (used in bandit/plugins/hashlib_new_insecure_functions.py)
 
     sets.append(utils.build_conf_dict(
         'tempnam', 'B325', ['os.tempnam', 'os.tmpnam'],
-        'Use of os.tempnam() and os.tmpnam() is vulnerable to symlink attacks. '
-        'Consider using tmpfile() instead.'
+        'Use of os.tempnam() and os.tmpnam() is vulnerable to symlink '
+        'attacks. Consider using tmpfile() instead.'
         ))
 
     return {'Call': sets}

--- a/bandit/blacklists/calls.py
+++ b/bandit/blacklists/calls.py
@@ -297,6 +297,23 @@ behavior that does not validate certificates or perform hostname checks.
 | B323 | unverified_context  | - ssl._create_unverified_context   | Medium    |
 +------+---------------------+------------------------------------+-----------+
 
+B325: tempnam
+--------------
+
+Use of os.tempnam() and os.tmpnam() is vulnerable to symlink attacks. Consider
+using tmpfile() instead.
+
+For further information:
+    https://docs.python.org/2.7/library/os.html#os.tempnam
+    https://bugs.python.org/issue17880
+
++------+---------------------+------------------------------------+-----------+
+| ID   |  Name               |  Calls                             |  Severity |
++======+=====================+====================================+===========+
+| B325 | tempnam             | - os.tempnam                       | Medium    |
+|      |                     | - os.tmpnam                        |           |
++------+---------------------+------------------------------------+-----------+
+
 """
 
 from bandit.blacklists import utils
@@ -539,6 +556,14 @@ def gen_blacklist():
         'using an insecure context via the _create_unverified_context that '
         'reverts to the previous behavior that does not validate certificates '
         'or perform hostname checks.'
+        ))
+
+    # skipped B324 due to use in bandit/plugins/hashlib_new_insecure_functions.py
+
+    sets.append(utils.build_conf_dict(
+        'tempnam', 'B325', ['os.tempnam', 'os.tmpnam'],
+        'Use of os.tempnam() and os.tmpnam() is vulnerable to symlink attacks. '
+        'Consider using tmpfile() instead.'
         ))
 
     return {'Call': sets}

--- a/examples/tempnam.py
+++ b/examples/tempnam.py
@@ -1,0 +1,13 @@
+from os import tempnam
+from os import tmpnam
+import os
+
+os.tmpnam()
+
+tmpnam()
+
+os.tempnam('dir1')
+os.tempnam('dir1', 'prefix1')
+
+tempnam('dir1')
+tempnam('dir1', 'prefix1')

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -264,6 +264,14 @@ class FunctionalTests(testtools.TestCase):
         }
         self.check_example('mktemp.py', expect)
 
+    def test_tempnam(self):
+        '''Test for `os.tempnam` / `os.tmpnam`.'''
+        expect = {
+            'SEVERITY': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 6, 'HIGH': 0},
+            'CONFIDENCE': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 0, 'HIGH': 6}
+        }
+        self.check_example('tempnam.py', expect)
+
     def test_nonsense(self):
         '''Test that a syntactically invalid module is skipped.'''
         self.run_example('nonsense.py')


### PR DESCRIPTION
Crikey, it's been a while...

This adds os.tempnam() / os.tmpnam() to the calls blacklist.

Per https://docs.python.org/2.7/library/os.html#os.tempnam and https://bugs.python.org/issue17880, this was left in 2.7 for legacy reasons, but use is potentially dangerous and tmpfile() is recommended instead.