### PR TITLE
Add subprocess.run to B602

### DIFF
--- a/bandit/plugins/injection_shell.py
+++ b/bandit/plugins/injection_shell.py
@@ -43,7 +43,8 @@ def gen_config(name):
             ['subprocess.Popen',
              'subprocess.call',
              'subprocess.check_call',
-             'subprocess.check_output'],
+             'subprocess.check_output',
+             'subprocess.run'],
 
             # Start a process with a function vulnerable to shell injection.
             'shell':

--- a/examples/subprocess_shell.py
+++ b/examples/subprocess_shell.py
@@ -26,6 +26,9 @@ subprocess.check_call('/bin/ls -l', shell=True)
 subprocess.check_output(['/bin/ls', '-l'])
 subprocess.check_output('/bin/ls -l', shell=True)
 
+subprocess.run(['/bin/ls', '-l'])
+subprocess.run('/bin/ls -l', shell=True)
+
 subprocess.Popen('/bin/ls *', shell=True)
 subprocess.Popen('/bin/ls %s' % ('something',), shell=True)
 subprocess.Popen('/bin/ls {}'.format('something'), shell=True)

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -417,8 +417,8 @@ class FunctionalTests(testtools.TestCase):
     def test_subprocess_shell(self):
         '''Test for `subprocess.Popen` with `shell=True`.'''
         expect = {
-            'SEVERITY': {'UNDEFINED': 0, 'LOW': 19, 'MEDIUM': 1, 'HIGH': 11},
-            'CONFIDENCE': {'UNDEFINED': 0, 'LOW': 1, 'MEDIUM': 0, 'HIGH': 30}
+            'SEVERITY': {'UNDEFINED': 0, 'LOW': 21, 'MEDIUM': 1, 'HIGH': 11},
+            'CONFIDENCE': {'UNDEFINED': 0, 'LOW': 1, 'MEDIUM': 0, 'HIGH': 32}
         }
         self.check_example('subprocess_shell.py', expect)
 


### PR DESCRIPTION
Python 3.5 introduced yet another subprocess function, run(). Like
the the APIs before it like call(), Popen(), etc it has a shell
parameter and can lead to shell injection when used incorrectly.

https://docs.python.org/3.5/library/subprocess.html#subprocess.run

Signed-off-by: Eric Brown <browne@vmware.com>