### PR TITLE
Add experimental Python 3.8-dev to test with

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       dist: xenial
       sudo: true
     - python: 3.8-dev
-      env: TOXENV=py
+      env: TOXENV=py38
       dist: xenial
       sudo: true
     - python: pypy

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ matrix:
       env: TOXENV=py37
       dist: xenial
       sudo: true
+    - python: 3.8-dev
+      env: TOXENV=py
+      dist: xenial
+      sudo: true
     - python: pypy
       env: TOXENV=pypy
 

--- a/bandit/formatters/html.py
+++ b/bandit/formatters/html.py
@@ -150,14 +150,21 @@ This formatter outputs the issues as HTML.
 .. versionadded:: 0.14.0
 
 """
+from __future__ import absolute_import
 
-import cgi
 import logging
 import sys
+
+import six
 
 from bandit.core import docs_utils
 from bandit.core import test_properties
 from bandit.formatters import utils
+
+if not six.PY2:
+    from html import escape as html_escape
+else:
+    from cgi import escape as html_escape
 
 LOG = logging.getLogger(__name__)
 
@@ -342,15 +349,15 @@ pre {
     for index, issue in enumerate(issues):
         if not baseline or len(issues[issue]) == 1:
             candidates = ''
-            safe_code = cgi.escape(issue.get_code(lines, True).
-                                   strip('\n').lstrip(' '))
+            safe_code = html_escape(issue.get_code(lines, True).
+                                    strip('\n').lstrip(' '))
             code = code_block.format(code=safe_code)
         else:
             candidates_str = ''
             code = ''
             for candidate in issues[issue]:
-                candidate_code = cgi.escape(candidate.get_code(lines, True).
-                                            strip('\n').lstrip(' '))
+                candidate_code = html_escape(candidate.get_code(lines, True).
+                                             strip('\n').lstrip(' '))
                 candidates_str += candidate_issue.format(code=candidate_code)
 
             candidates = candidate_block.format(candidate_list=candidates_str)


### PR DESCRIPTION
This patch adds the prerelease version of Python 3.8 to the testing.
Although Bandit is unlikely to have compile errors with any future
version, this step allows us to get a head start on any that may
arise.