### PR TITLE
Report dill usage

### DIFF
--- a/bandit/blacklists/calls.py
+++ b/bandit/blacklists/calls.py
@@ -27,7 +27,8 @@ ast.Call nodes.
 B301: pickle
 ------------
 
-Pickle library appears to be in use, possible security issue.
+Pickle and modules that wrap it can be unsafe when used to
+unserialize untusted data, possible security issue.
 
 +------+---------------------+------------------------------------+-----------+
 | ID   |  Name               |  Calls                             |  Severity |
@@ -38,6 +39,9 @@ Pickle library appears to be in use, possible security issue.
 |      |                     | - cPickle.loads                    |           |
 |      |                     | - cPickle.load                     |           |
 |      |                     | - cPickle.Unpickler                |           |
+|      |                     | - dill.loads                       |           |
+|      |                     | - dill.load                        |           |
+|      |                     | - dill.Unpickler                   |           |
 +------+---------------------+------------------------------------+-----------+
 
 B302: marshal
@@ -339,8 +343,12 @@ def gen_blacklist():
          'pickle.Unpickler',
          'cPickle.loads',
          'cPickle.load',
-         'cPickle.Unpickler'],
-        'Pickle library appears to be in use, possible security issue.'
+         'cPickle.Unpickler',
+         'dill.loads',
+         'dill.load',
+         'dill.Unpickler'],
+        'Pickle and modules that wrap it can be unsafe when used to '
+        'unserialize untusted data, possible security issue.'
         ))
 
     sets.append(utils.build_conf_dict(

--- a/bandit/blacklists/calls.py
+++ b/bandit/blacklists/calls.py
@@ -28,7 +28,7 @@ B301: pickle
 ------------
 
 Pickle and modules that wrap it can be unsafe when used to
-unserialize untusted data, possible security issue.
+deserialize untrusted data, possible security issue.
 
 +------+---------------------+------------------------------------+-----------+
 | ID   |  Name               |  Calls                             |  Severity |
@@ -348,7 +348,7 @@ def gen_blacklist():
          'dill.load',
          'dill.Unpickler'],
         'Pickle and modules that wrap it can be unsafe when used to '
-        'unserialize untusted data, possible security issue.'
+        'deserialize untrusted data, possible security issue.'
         ))
 
     sets.append(utils.build_conf_dict(

--- a/bandit/blacklists/imports.py
+++ b/bandit/blacklists/imports.py
@@ -59,6 +59,7 @@ Consider possible security implications associated with these modules.
 +======+=====================+====================================+===========+
 | B403 | import_pickle       | - pickle                           | low       |
 |      |                     | - cPickle                          |           |
+|      |                     | - dill                             |           |
 +------+---------------------+------------------------------------+-----------+
 
 B404: import_subprocess
@@ -252,7 +253,7 @@ def gen_blacklist():
         ))
 
     sets.append(utils.build_conf_dict(
-        'import_pickle', 'B403', ['pickle', 'cPickle'],
+        'import_pickle', 'B403', ['pickle', 'cPickle', 'dill'],
         'Consider possible security implications associated with '
         '{name} module.', 'LOW'
         ))

--- a/examples/dill.py
+++ b/examples/dill.py
@@ -1,0 +1,14 @@
+import dill
+import StringIO
+
+# dill
+pick = dill.dumps({'a': 'b', 'c': 'd'})
+print(dill.loads(pick))
+
+file_obj = StringIO.StringIO()
+dill.dump([1, 2, '3'], file_obj)
+file_obj.seek(0)
+print(dill.load(file_obj))
+
+file_obj.seek(0)
+print(dill.Undillr(file_obj).load())

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -354,6 +354,14 @@ class FunctionalTests(testtools.TestCase):
         }
         self.check_example('pickle_deserialize.py', expect)
 
+    def test_dill(self):
+        '''Test for the `dill` module.'''
+        expect = {
+            'SEVERITY': {'UNDEFINED': 0, 'LOW': 1, 'MEDIUM': 2, 'HIGH': 0},
+            'CONFIDENCE': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 0, 'HIGH': 3}
+        }
+        self.check_example('dill.py', expect)
+
     def test_popen_wrappers(self):
         '''Test the `popen2` and `commands` modules.'''
         expect = {


### PR DESCRIPTION
Dill is a wrapper around pickle and thus is vulnerable to the same
threat. Dill documentation states that dill "is not intended to be secure
against erroneously or maliciously constructed data. It is left to the
user to decide whether the data they unpickle is from a trustworthy
source." (https://pypi.org/project/dill/)