### PR TITLE
Add more_info URL to text output

### DIFF
--- a/bandit/formatters/text.py
+++ b/bandit/formatters/text.py
@@ -27,10 +27,9 @@ This formatter outputs the issues as plain text.
     >> Issue: [B301:blacklist_calls] Use of unsafe yaml load. Allows
        instantiation of arbitrary objects. Consider yaml.safe_load().
 
-       More Info: https://bandit.readthedocs.io/en/latest/
-
        Severity: Medium   Confidence: High
        Location: examples/yaml_load.py:5
+       More Info: https://bandit.readthedocs.io/en/latest/
     4       ystr = yaml.dump({'a' : 1, 'b' : 2, 'c' : 3})
     5       y = yaml.load(ystr)
     6       yaml.dump(y)
@@ -84,14 +83,14 @@ def _output_issue_str(issue, indent, show_lineno=True, show_code=True,
     bits.append("%s>> Issue: [%s:%s] %s" % (
         indent, issue.test_id, issue.test, issue.text))
 
-    bits.append("%s   More Info: %s" % (
-        indent, docs_utils.get_url(issue.test_id)))
-
     bits.append("%s   Severity: %s   Confidence: %s" % (
         indent, issue.severity.capitalize(), issue.confidence.capitalize()))
 
     bits.append("%s   Location: %s:%s" % (
         indent, issue.fname, issue.lineno if show_lineno else ""))
+
+    bits.append("%s   More Info: %s" % (
+        indent, docs_utils.get_url(issue.test_id)))
 
     if show_code:
         bits.extend([indent + l for l in

--- a/bandit/formatters/text.py
+++ b/bandit/formatters/text.py
@@ -27,6 +27,8 @@ This formatter outputs the issues as plain text.
     >> Issue: [B301:blacklist_calls] Use of unsafe yaml load. Allows
        instantiation of arbitrary objects. Consider yaml.safe_load().
 
+       More Info: https://bandit.readthedocs.io/en/latest/
+
        Severity: Medium   Confidence: High
        Location: examples/yaml_load.py:5
     4       ystr = yaml.dump({'a' : 1, 'b' : 2, 'c' : 3})
@@ -44,6 +46,7 @@ import logging
 import sys
 
 from bandit.core import constants
+from bandit.core import docs_utils
 from bandit.core import test_properties
 from bandit.formatters import utils
 
@@ -80,6 +83,9 @@ def _output_issue_str(issue, indent, show_lineno=True, show_code=True,
     bits = []
     bits.append("%s>> Issue: [%s:%s] %s" % (
         indent, issue.test_id, issue.test, issue.text))
+
+    bits.append("%s   More Info: %s" % (
+        indent, docs_utils.get_url(issue.test_id)))
 
     bits.append("%s   Severity: %s   Confidence: %s" % (
         indent, issue.severity.capitalize(), issue.confidence.capitalize()))

--- a/tests/unit/formatters/test_text.py
+++ b/tests/unit/formatters/test_text.py
@@ -42,13 +42,13 @@ class TextFormatterTests(testtools.TestCase):
             return_val = ["{}>> Issue: [{}:{}] {}".
                           format(_indent_val, _issue.test_id, _issue.test,
                                  _issue.text),
-                          "{}   More Info: {}".format(
-                              _indent_val, docs_utils.get_url(_issue.test_id)),
                           "{}   Severity: {}   Confidence: {}".
                           format(_indent_val, _issue.severity.capitalize(),
                                  _issue.confidence.capitalize()),
                           "{}   Location: {}:{}".
-                          format(_indent_val, _issue.fname, _issue.lineno)]
+                          format(_indent_val, _issue.fname, _issue.lineno),
+                          "{}   More Info: {}".format(
+                              _indent_val, docs_utils.get_url(_issue.test_id))]
             if _code:
                 return_val.append("{}{}".format(_indent_val, _code))
             return '\n'.join(return_val)

--- a/tests/unit/formatters/test_text.py
+++ b/tests/unit/formatters/test_text.py
@@ -21,6 +21,7 @@ import testtools
 
 import bandit
 from bandit.core import config
+from bandit.core import docs_utils
 from bandit.core import issue
 from bandit.core import manager
 from bandit.formatters import text as b_text
@@ -41,6 +42,8 @@ class TextFormatterTests(testtools.TestCase):
             return_val = ["{}>> Issue: [{}:{}] {}".
                           format(_indent_val, _issue.test_id, _issue.test,
                                  _issue.text),
+                          "{}   More Info: {}".format(
+                              _indent_val, docs_utils.get_url(_issue.test_id)),
                           "{}   Severity: {}   Confidence: {}".
                           format(_indent_val, _issue.severity.capitalize(),
                                  _issue.confidence.capitalize()),


### PR DESCRIPTION
Outputting bandit report as text does not put `more_info` URL while it
would if the output format is YAML or JSON. This patch set adds the
`more_info` URL to the text display.

Signed-off-by: Tin Lam <tin@irrational.io>