### PR TITLE
Add more_info URL to screen formatter

### DIFF
--- a/bandit/formatters/screen.py
+++ b/bandit/formatters/screen.py
@@ -29,6 +29,7 @@ This formatter outputs the issues as color coded text.
 
        Severity: Medium   Confidence: High
        Location: examples/yaml_load.py:5
+       More Info: https://bandit.readthedocs.io/en/latest/
     4       ystr = yaml.dump({'a' : 1, 'b' : 2, 'c' : 3})
     5       y = yaml.load(ystr)
     6       yaml.dump(y)
@@ -44,6 +45,7 @@ import logging
 import sys
 
 from bandit.core import constants
+from bandit.core import docs_utils
 from bandit.core import test_properties
 
 LOG = logging.getLogger(__name__)
@@ -99,6 +101,9 @@ def _output_issue_str(issue, indent, show_lineno=True, show_code=True,
         indent, issue.fname,
         issue.lineno if show_lineno else "",
         COLOR['DEFAULT']))
+
+    bits.append("%s   More Info: %s" % (
+        indent, docs_utils.get_url(issue.test_id)))
 
     if show_code:
         bits.extend([indent + l for l in

--- a/bandit/formatters/screen.py
+++ b/bandit/formatters/screen.py
@@ -18,13 +18,13 @@ r"""
 Screen formatter
 ================
 
-This formatter outputs the issues as color coded text.
+This formatter outputs the issues as color coded text to screen.
 
 :Example:
 
 .. code-block:: none
 
-    >> Issue: [B301:blacklist_calls] Use of unsafe yaml load. Allows
+    >> Issue: [B506: yaml_load] Use of unsafe yaml load. Allows
        instantiation of arbitrary objects. Consider yaml.safe_load().
 
        Severity: Medium   Confidence: High

--- a/tests/unit/formatters/test_screen.py
+++ b/tests/unit/formatters/test_screen.py
@@ -21,6 +21,7 @@ import testtools
 
 import bandit
 from bandit.core import config
+from bandit.core import docs_utils
 from bandit.core import issue
 from bandit.core import manager
 from bandit.formatters import screen
@@ -46,7 +47,9 @@ class ScreenFormatterTests(testtools.TestCase):
                                  _issue.confidence.capitalize()),
                           "{}   Location: {}:{}{}".
                           format(_indent_val, _issue.fname, _issue.lineno,
-                                 screen.COLOR['DEFAULT'])]
+                                 screen.COLOR['DEFAULT']),
+                          "{}   More Info: {}".format(
+                              _indent_val, docs_utils.get_url(_issue.test_id))]
             if _code:
                 return_val.append("{}{}".format(_indent_val, _code))
             return '\n'.join(return_val)


### PR DESCRIPTION
Patch set adds more_info URL to the screen formatter.

Partially-Closes: #323

Signed-off-by: Tin Lam <tin@irrational.io>