### PR TITLE
Add more_info URL to csv formatter

### DIFF
--- a/bandit/formatters/csv.py
+++ b/bandit/formatters/csv.py
@@ -24,12 +24,15 @@ This formatter outputs the issues in a comma separated values format.
 .. code-block:: none
 
     filename,test_name,test_id,issue_severity,issue_confidence,issue_text,
-    more_info,line_number,line_range
+    line_number,line_range,more_info
     examples/yaml_load.py,blacklist_calls,B301,MEDIUM,HIGH,"Use of unsafe yaml
     load. Allows instantiation of arbitrary objects. Consider yaml.safe_load().
-    ",https://bandit.readthedocs.io/en/latest/,5,[5]
+    ",5,[5],https://bandit.readthedocs.io/en/latest/
 
 .. versionadded:: 0.11.0
+
+.. versionchanged:: 1.5.0
+    New field `more_info` added to output
 
 """
 # Necessary for this formatter to work when imported on Python 2. Importing
@@ -65,9 +68,9 @@ def report(manager, fileobj, sev_level, conf_level, lines=-1):
                       'issue_severity',
                       'issue_confidence',
                       'issue_text',
-                      'more_info',
                       'line_number',
-                      'line_range']
+                      'line_range',
+                      'more_info']
 
         writer = csv.DictWriter(fileobj, fieldnames=fieldnames,
                                 extrasaction='ignore')

--- a/bandit/formatters/csv.py
+++ b/bandit/formatters/csv.py
@@ -68,7 +68,6 @@ def report(manager, fileobj, sev_level, conf_level, lines=-1):
                       'issue_severity',
                       'issue_confidence',
                       'issue_text',
-                      'more_info',
                       'line_number',
                       'line_range',
                       'more_info']

--- a/bandit/formatters/csv.py
+++ b/bandit/formatters/csv.py
@@ -24,10 +24,10 @@ This formatter outputs the issues in a comma separated values format.
 .. code-block:: none
 
     filename,test_name,test_id,issue_severity,issue_confidence,issue_text,
-    line_number,line_range
+    more_info,line_number,line_range
     examples/yaml_load.py,blacklist_calls,B301,MEDIUM,HIGH,"Use of unsafe yaml
     load. Allows instantiation of arbitrary objects. Consider yaml.safe_load().
-    ",5,[5]
+    ",https://bandit.readthedocs.io/en/latest/,5,[5]
 
 .. versionadded:: 0.11.0
 
@@ -39,6 +39,8 @@ from __future__ import absolute_import
 import csv
 import logging
 import sys
+
+from bandit.core import docs_utils
 
 LOG = logging.getLogger(__name__)
 
@@ -63,6 +65,7 @@ def report(manager, fileobj, sev_level, conf_level, lines=-1):
                       'issue_severity',
                       'issue_confidence',
                       'issue_text',
+                      'more_info',
                       'line_number',
                       'line_range']
 
@@ -70,7 +73,9 @@ def report(manager, fileobj, sev_level, conf_level, lines=-1):
                                 extrasaction='ignore')
         writer.writeheader()
         for result in results:
-            writer.writerow(result.as_dict(with_code=False))
+            r = result.as_dict(with_code=False)
+            r['more_info'] = docs_utils.get_url(r['test_id'])
+            writer.writerow(r)
 
     if fileobj.name != sys.stdout.name:
         LOG.info("CSV output written to file: %s", fileobj.name)

--- a/tests/unit/formatters/test_csv.py
+++ b/tests/unit/formatters/test_csv.py
@@ -64,3 +64,4 @@ class CsvFormatterTests(testtools.TestCase):
             self.assertEqual(six.text_type(self.context['linerange']),
                              data['line_range'])
             self.assertEqual(self.check_name, data['test_name'])
+            self.assertIsNotNone(data['more_info'])


### PR DESCRIPTION
Patch set adds more_info URL to the csv formatter.

Closes: #323

Signed-off-by: Tin Lam <tin@irrational.io>