### PR TITLE
New plugin to check for ignoring host keys

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -230,6 +230,7 @@ Usage::
       B504  ssl_with_no_version
       B505  weak_cryptographic_key
       B506  yaml_load
+      B507  ssh_no_host_key_verification
       B601  paramiko_calls
       B602  subprocess_popen_with_shell_equals_true
       B603  subprocess_without_shell_equals_true

--- a/bandit/plugins/ssh_no_host_key_verification.py
+++ b/bandit/plugins/ssh_no_host_key_verification.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2018 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+r"""
+==========================================
+B507: Test for missing host key validation
+==========================================
+
+Encryption in general is typically critical to the security of many
+applications.  Using SSH can greatly increase security by guaranteeing the
+identity of the party you are communicating with.  This is accomplished by one
+or both parties presenting trusted host keys during the connection
+initialization phase of SSH.
+
+When paramiko methods are used, host keys are verified by default. If host key
+verification is disabled, Bandit will return a HIGH severity error.
+
+:Example:
+
+.. code-block:: none
+
+    >> Issue: [B507:ssh_no_host_key_verification] Paramiko call with policy set
+    to automatically trust the unknown host key.
+    Severity: High   Confidence: Medium
+    Location: examples/no_host_key_verification.py:4
+    3   ssh_client = client.SSHClient()
+    4   ssh_client.set_missing_host_key_policy(client.AutoAddPolicy)
+    5   ssh_client.set_missing_host_key_policy(client.WarningPolicy)
+
+
+.. versionadded:: 1.5.1
+
+"""
+
+import bandit
+from bandit.core import test_properties as test
+
+
+@test.checks('Call')
+@test.test_id('B507')
+def ssh_no_host_key_verification(context):
+    if (context.is_module_imported_like('paramiko') and
+            context.call_function_name == 'set_missing_host_key_policy'):
+        if (context.call_args and
+                context.call_args[0] in ['AutoAddPolicy', 'WarningPolicy']):
+            issue = bandit.Issue(
+                severity=bandit.HIGH,
+                confidence=bandit.MEDIUM,
+                text='Paramiko call with policy set to automatically trust '
+                     'the unknown host key.',
+                lineno=context.get_lineno_for_call_arg(
+                    'set_missing_host_key_policy'),
+            )
+            return issue

--- a/doc/source/plugins/b507_ssh_no_host_key_verification.rst
+++ b/doc/source/plugins/b507_ssh_no_host_key_verification.rst
@@ -1,0 +1,5 @@
+----------------------------------
+B507: ssh_no_host_key_verification
+----------------------------------
+
+.. automodule:: bandit.plugins.ssh_no_host_key_verification

--- a/examples/no_host_key_verification.py
+++ b/examples/no_host_key_verification.py
@@ -1,0 +1,5 @@
+from paramiko import client
+
+ssh_client = client.SSHClient()
+ssh_client.set_missing_host_key_policy(client.AutoAddPolicy)
+ssh_client.set_missing_host_key_policy(client.WarningPolicy)

--- a/setup.cfg
+++ b/setup.cfg
@@ -118,6 +118,9 @@ bandit.plugins =
     # bandit/plugins/yaml_load.py
     yaml_load = bandit.plugins.yaml_load:yaml_load
 
+    # bandit/plugins/ssh_no_host_key_verification.py
+    ssh_no_host_key_verification = bandit.plugins.ssh_no_host_key_verification:ssh_no_host_key_verification
+
 [build_sphinx]
 all_files = 1
 build-dir = doc/build

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -472,6 +472,14 @@ class FunctionalTests(testtools.TestCase):
         }
         self.check_example('yaml_load.py', expect)
 
+    def test_host_key_verification(self):
+        '''Test for ignoring host key verification.'''
+        expect = {
+            'SEVERITY': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 0, 'HIGH': 2},
+            'CONFIDENCE': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 2, 'HIGH': 0}
+        }
+        self.check_example('no_host_key_verification.py', expect)
+
     def test_jinja2_templating(self):
         '''Test jinja templating for potential XSS bugs.'''
         expect = {


### PR DESCRIPTION
This new plugin adds a check that detects whether some code using
paramiko is ignoring the host key verification.  Ignoring a host
key is the equivalent of ignoring a certificate as part of the
TLS protocol.

Original author: Eric Brown <browne@vmware.com>

Fixes Issue: #357