### PR TITLE
Fix PY2 ast.Arg AttributeError in general_hardcoded_password.py

### DIFF
--- a/bandit/plugins/general_hardcoded_password.py
+++ b/bandit/plugins/general_hardcoded_password.py
@@ -17,6 +17,7 @@
 import ast
 import sys
 
+import six
 import bandit
 from bandit.core import test_properties as test
 
@@ -208,8 +209,9 @@ def hardcoded_password_default(context):
     defs.extend(context.node.args.defaults)
 
     # go through all (param, value)s and look for candidates
+    ast_argtype = ast.Arg if not six.PY2 else ast.arguments
     for key, val in zip(context.node.args.args, defs):
-        if isinstance(key, ast.Name) or isinstance(key, ast.arg):
-            check = key.arg if sys.version_info.major > 2 else key.id  # Py3
+        if isinstance(key, ast.Name) or isinstance(key, ast_argtype):
+            check = key.arg if not six.PY2 else key.id
             if isinstance(val, ast.Str) and check in CANDIDATES:
                 return _report(val.s)

--- a/bandit/plugins/general_hardcoded_password.py
+++ b/bandit/plugins/general_hardcoded_password.py
@@ -15,11 +15,10 @@
 # under the License.
 
 import ast
-import sys
 
-import six
 import bandit
 from bandit.core import test_properties as test
+import six
 
 
 CANDIDATES = set(["password", "pass", "passwd", "pwd", "secret", "token",
@@ -209,7 +208,7 @@ def hardcoded_password_default(context):
     defs.extend(context.node.args.defaults)
 
     # go through all (param, value)s and look for candidates
-    ast_argtype = ast.Arg if not six.PY2 else ast.arguments
+    ast_argtype = ast.arg if not six.PY2 else ast.arguments
     for key, val in zip(context.node.args.args, defs):
         if isinstance(key, ast.Name) or isinstance(key, ast_argtype):
             check = key.arg if not six.PY2 else key.id

--- a/examples/hardcoded-passwords.py
+++ b/examples/hardcoded-passwords.py
@@ -19,6 +19,9 @@ def doLogin(password="blerg"):
 def NoMatch3(a, b):
     pass
 
+def aFunctionWithTupleArg(a, (b, c)):
+    pass
+
 doLogin(password="blerg")
 password = "blerg"
 d["password"] = "blerg"


### PR DESCRIPTION
Fix `ast.arg` should be `ast.arguments` in Python 2.

This error was raised during our first run by default `bandit -r src` under Python 2.7.15.
```
[tester]	ERROR	Bandit internal error running: hardcoded_password_default
on file something_py2.py at line 527: 'module' object has no attribute 'arg'
Traceback (most recent call last):
  File "bandit/core/tester.py", line 64, in run_tests
    result = test(context)
  File "bandit/plugins/general_hardcoded_password.py", line 212, in hardcoded_password_default
    if isinstance(key, ast.Name) or isinstance(key, ast.arg):
AttributeError: 'module' object has no attribute 'arg'
```