### PR TITLE
Adding test case for traversal crash

### DIFF
--- a/examples/imports-with-importlib.py
+++ b/examples/imports-with-importlib.py
@@ -3,3 +3,7 @@ a = importlib.import_module('os')
 b = importlib.import_module('pickle')
 c = importlib.__import__('sys')
 d = importlib.__import__('subprocess')
+
+# Do not crash when target is an expression
+e = importlib.import_module(MODULE_MAP[key])
+f = importlib.__import__(MODULE_MAP[key])


### PR DESCRIPTION
Follow up for #369, instead of adding a specific no-op test case, just add the relevant input on the existing one as in _weak_cryptographic_key_sizes.py_.

Signed-off-by: Antoine Salon <asalon@vmware.com>