### PR TITLE
Properly handle nosec strings in code

### DIFF
--- a/examples/nosec.py
+++ b/examples/nosec.py
@@ -3,3 +3,5 @@ subprocess.Popen('/bin/ls *', #nosec (at the start of function call)
                  shell=True)
 subprocess.Popen('/bin/ls *',
                  shell=True)  #nosec (on the specific kwarg line)
+subprocess.Popen('#nosec', shell=True)
+subprocess.Popen('/bin/ls *', shell=True) # type: … # nosec # noqa: E501 ; pylint: disable=line-too-long

--- a/pylintrc
+++ b/pylintrc
@@ -12,6 +12,7 @@
 # TODO(browne): fix these in the future
 # C0103: invalid-name
 # E1101: no-member
+# E1111: assignment-from-no-return
 # R0204: redefined-variable-type
 # R0902: too-many-instance-attributes
 # R0912: too-many-branches
@@ -28,7 +29,7 @@
 # W0613: unused-argument
 # W0621: redefined-outer-name
 # W0703: broad-except
-disable=C0111,C0301,C0325,F0401,W0511,W0142,W0622,C0103,E1101,R0204,R0902,R0912,R0913,R0914,R0915,W0110,W0141,W0201,W0401,W0603,W0212,W0612,W0613,W0621,W0703
+disable=C0111,C0301,C0325,F0401,W0511,W0142,W0622,C0103,E1101,E1111,R0204,R0902,R0912,R0913,R0914,R0915,W0110,W0141,W0201,W0401,W0603,W0212,W0612,W0613,W0621,W0703
 
 [Basic]
 # Variable names can be 1 to 31 characters long, with lowercase and underscores

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -708,8 +708,8 @@ class FunctionalTests(testtools.TestCase):
 
     def test_nosec(self):
         expect = {
-            'SEVERITY': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 0, 'HIGH': 0},
-            'CONFIDENCE': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 0, 'HIGH': 0}
+            'SEVERITY': {'UNDEFINED': 0, 'LOW': 2, 'MEDIUM': 0, 'HIGH': 0},
+            'CONFIDENCE': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 0, 'HIGH': 2}
         }
         self.check_example('nosec.py', expect)
 

--- a/tests/functional/test_runtime.py
+++ b/tests/functional/test_runtime.py
@@ -15,6 +15,7 @@
 import os
 import subprocess
 
+import six
 import testtools
 
 
@@ -111,11 +112,13 @@ class RuntimeTests(testtools.TestCase):
             ['bandit', ], ['nonsense2.py', ]
         )
         self.assertEqual(0, retcode)
-        self.assertIn(
-            "Exception occurred when executing tests against", output
-        )
         self.assertIn("Files skipped (1):", output)
-        self.assertIn("nonsense2.py (exception while scanning file)", output)
+        if six.PY2:
+            self.assertIn("nonsense2.py (exception while scanning file)",
+                          output)
+        else:
+            self.assertIn("nonsense2.py (syntax error while parsing AST",
+                          output)
 
     def test_example_imports(self):
         (retcode, output) = self._test_example(['bandit', ], ['imports.py', ])


### PR DESCRIPTION
The string "# nosec" has a chance (albeit remote) that it can be
part of the code on the line not just within the comment. Bandit
currently checks the entire line for that string.

This patch tokenizes the line of input to figure out what piece
is a comment, then compares whether that comment contains "# nosec".

Fixes #383

Signed-off-by: Eric Brown <browne@vmware.com>