### PR TITLE
Fix Pylint warning W0612: use of unused variables

### DIFF
--- a/bandit/cli/baseline.py
+++ b/bandit/cli/baseline.py
@@ -170,7 +170,7 @@ def initialize():
                         default='terminal', help='specify output format',
                         choices=valid_baseline_formats)
 
-    args, unknown = parser.parse_known_args()
+    args, _ = parser.parse_known_args()
 
     # #################### Setup Output #######################################
     # set the output format, or use a default if not provided

--- a/bandit/cli/main.py
+++ b/bandit/cli/main.py
@@ -65,7 +65,7 @@ def _get_options_from_ini(ini_path, target):
         bandit_files = []
 
         for t in target:
-            for root, dirnames, filenames in os.walk(t):
+            for root, _, filenames in os.walk(t):
                 for filename in fnmatch.filter(filenames, '.bandit'):
                     bandit_files.append(os.path.join(root, filename))
 

--- a/bandit/core/manager.py
+++ b/bandit/core/manager.py
@@ -321,7 +321,7 @@ def _get_files_from_dir(files_dir, included_globs=None,
     files_list = set()
     excluded_files = set()
 
-    for root, subdirs, files in os.walk(files_dir):
+    for root, _, files in os.walk(files_dir):
         for filename in files:
             path = os.path.join(root, filename)
             if _is_file_included(path, included_globs, excluded_path_strings):

--- a/bandit/core/metrics.py
+++ b/bandit/core/metrics.py
@@ -90,7 +90,7 @@ class Metrics(object):
         """
         issue_counts = {}
         for score in scores:
-            for (criteria, default) in constants.CRITERIA:
+            for (criteria, _) in constants.CRITERIA:
                 for i, rank in enumerate(constants.RANKING):
                     label = '{0}.{1}'.format(criteria, rank)
                     if label not in issue_counts:

--- a/bandit/core/test_set.py
+++ b/bandit/core/test_set.py
@@ -45,7 +45,7 @@ class BanditTestSet(object):
         exc = set(profile.get('exclude', []))
 
         all_blacklist_tests = set()
-        for _node, tests in extman.blacklist.items():
+        for _, tests in extman.blacklist.items():
             all_blacklist_tests.update(t['id'] for t in tests)
 
         # this block is purely for backwards compatibility, the rules are as

--- a/bandit/formatters/screen.py
+++ b/bandit/formatters/screen.py
@@ -78,7 +78,7 @@ def get_verbose_details(manager):
 def get_metrics(manager):
     bits = []
     bits.append(header("\nRun metrics:"))
-    for (criteria, default) in constants.CRITERIA:
+    for (criteria, _) in constants.CRITERIA:
         bits.append("\tTotal issues (by %s):" % (criteria.lower()))
         for rank in constants.RANKING:
             bits.append("\t\t%s: %s" % (

--- a/bandit/formatters/text.py
+++ b/bandit/formatters/text.py
@@ -67,7 +67,7 @@ def get_verbose_details(manager):
 def get_metrics(manager):
     bits = []
     bits.append("\nRun metrics:")
-    for (criteria, default) in constants.CRITERIA:
+    for (criteria, _) in constants.CRITERIA:
         bits.append("\tTotal issues (by %s):" % (criteria.lower()))
         for rank in constants.RANKING:
             bits.append("\t\t%s: %s" % (

--- a/pylintrc
+++ b/pylintrc
@@ -23,11 +23,10 @@
 # W0212: protected-access
 # W0401: wildcard-import
 # W0603: global-statement
-# W0612: unused-variable
 # W0613: unused-argument
 # W0621: redefined-outer-name
 # W0703: broad-except
-disable=C0111,C0301,C0325,F0401,W0511,W0142,W0622,C0103,E1101,R0902,R0912,R0913,R0914,R0915,W0110,W0141,W0201,W0401,W0603,W0212,W0612,W0613,W0621,W0703
+disable=C0111,C0301,C0325,F0401,W0511,W0142,W0622,C0103,E1101,R0902,R0912,R0913,R0914,R0915,W0110,W0141,W0201,W0401,W0603,W0212,W0613,W0621,W0703
 
 [Basic]
 # Variable names can be 1 to 31 characters long, with lowercase and underscores


### PR DESCRIPTION
This patch removes the skipping of pylint check W0612: unused-variable.
Unused variables are replaced with _.

Signed-off-by: Eric Brown <browne@vmware.com>