### PR TITLE
Allow failures on dev branch of Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,11 @@ matrix:
       sudo: true
     - python: pypy
       env: TOXENV=pypy
+  allow_failures:
+    - python: 3.8-dev
+      env: TOXENV=py38
+      dist: xenial
+      sudo: true
 
 notifications:
   email:


### PR DESCRIPTION
Since Python 3.8 is going through significant changes, we should
allow failures and not block other commits from merging because
of 3.8 compatibility.

Signed-off-by: Eric Brown <browne@vmware.com>