### PR TITLE
Replace use of _ast with ast

### DIFF
--- a/bandit/core/utils.py
+++ b/bandit/core/utils.py
@@ -14,7 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import _ast
 import ast
 import logging
 import os.path
@@ -46,11 +45,11 @@ def _get_attr_qual_name(node, aliases):
     :param aliases: Import aliases dictionary
     :returns: Qualified name referred to by the attribute or name.
     '''
-    if isinstance(node, _ast.Name):
+    if isinstance(node, ast.Name):
         if node.id in aliases:
             return aliases[node.id]
         return node.id
-    elif isinstance(node, _ast.Attribute):
+    elif isinstance(node, ast.Attribute):
         name = '%s.%s' % (_get_attr_qual_name(node.value, aliases), node.attr)
         if name in aliases:
             return aliases[name]
@@ -60,11 +59,11 @@ def _get_attr_qual_name(node, aliases):
 
 
 def get_call_name(node, aliases):
-    if isinstance(node.func, _ast.Name):
+    if isinstance(node.func, ast.Name):
         if deepgetattr(node, 'func.id') in aliases:
             return aliases[deepgetattr(node, 'func.id')]
         return deepgetattr(node, 'func.id')
-    elif isinstance(node.func, _ast.Attribute):
+    elif isinstance(node.func, ast.Attribute):
         return _get_attr_qual_name(node.func, aliases)
     else:
         return ""
@@ -76,7 +75,7 @@ def get_func_name(node):
 
 def get_qual_attr(node, aliases):
     prefix = ""
-    if isinstance(node, _ast.Attribute):
+    if isinstance(node, ast.Attribute):
         try:
             val = deepgetattr(node, 'value.id')
             if val in aliases:

--- a/bandit/plugins/general_hardcoded_password.py
+++ b/bandit/plugins/general_hardcoded_password.py
@@ -17,6 +17,8 @@
 import ast
 import sys
 
+import six
+
 import bandit
 from bandit.core import test_properties as test
 
@@ -210,6 +212,10 @@ def hardcoded_password_default(context):
     # go through all (param, value)s and look for candidates
     for key, val in zip(context.node.args.args, defs):
         if isinstance(key, ast.Name) or isinstance(key, ast.arg):
-            check = key.arg if sys.version_info.major > 2 else key.id  # Py3
-            if isinstance(val, ast.Str) and check in CANDIDATES:
+            check = key.arg if not six.PY2 else key.id  # Py3
+
+            if (sys.version_info >= (3, 8) and isinstance(val, ast.Constant)
+                    and check in CANDIDATES):
+                return _report(val.value)
+            elif isinstance(val, ast.Str) and check in CANDIDATES:
                 return _report(val.s)


### PR DESCRIPTION
Bandit shouldn't be using the protected version of the AST (_ast).
This is likey to change and that's exactly what happened in Python
3.8 as they have deprecated the ast classes such as ast.Num and
removed the _ast.Num.

Signed-off-by: Eric Brown <browne@vmware.com>