### PR TITLE
Fix more info line to be in color also

### DIFF
--- a/bandit/formatters/screen.py
+++ b/bandit/formatters/screen.py
@@ -97,13 +97,12 @@ def _output_issue_str(issue, indent, show_lineno=True, show_code=True,
     bits.append("%s   Severity: %s   Confidence: %s" % (
         indent, issue.severity.capitalize(), issue.confidence.capitalize()))
 
-    bits.append("%s   Location: %s:%s%s" % (
+    bits.append("%s   Location: %s:%s" % (
         indent, issue.fname,
-        issue.lineno if show_lineno else "",
-        COLOR['DEFAULT']))
+        issue.lineno if show_lineno else ""))
 
-    bits.append("%s   More Info: %s" % (
-        indent, docs_utils.get_url(issue.test_id)))
+    bits.append("%s   More Info: %s%s" % (
+        indent, docs_utils.get_url(issue.test_id), COLOR['DEFAULT']))
 
     if show_code:
         bits.extend([indent + l for l in

--- a/tests/unit/formatters/test_screen.py
+++ b/tests/unit/formatters/test_screen.py
@@ -45,11 +45,11 @@ class ScreenFormatterTests(testtools.TestCase):
                           "{}   Severity: {}   Confidence: {}".
                           format(_indent_val, _issue.severity.capitalize(),
                                  _issue.confidence.capitalize()),
-                          "{}   Location: {}:{}{}".
-                          format(_indent_val, _issue.fname, _issue.lineno,
-                                 screen.COLOR['DEFAULT']),
-                          "{}   More Info: {}".format(
-                              _indent_val, docs_utils.get_url(_issue.test_id))]
+                          "{}   Location: {}:{}".
+                          format(_indent_val, _issue.fname, _issue.lineno),
+                          "{}   More Info: {}{}".format(
+                              _indent_val, docs_utils.get_url(_issue.test_id),
+                              screen.COLOR['DEFAULT'])]
             if _code:
                 return_val.append("{}{}".format(_indent_val, _code))
             return '\n'.join(return_val)


### PR DESCRIPTION
The More Info line is something newly introduced for the screen
formatter. The coloring of these lines work by adding a color
marker at the bbeginning and end of the multiline block.  So the
block just needed to be extended by one.

Fixes #407

Signed-off-by: Eric Brown <browne@vmware.com>