### PR TITLE
Remove unneeded trailing paren in link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -253,7 +253,7 @@ Version control integration
 ---------------------------
 
 Use `pre-commit <https://pre-commit.com/>`_. Once you `have it
-installed <https://pre-commit.com/#install)>`_, add this to the
+installed <https://pre-commit.com/#install>`_, add this to the
 `.pre-commit-config.yaml` in your repository
 (be sure to update `rev` to point to a real git tag/revision!)::
 


### PR DESCRIPTION
The recent commit 8f4c216a91d38122228c0cb497f01a9d3dfbd9c8 to
add a pre-commit config includes a link in the README to an install
location.  A minor issue with the link is that it contains a trailing
')' which breaks the anchor location.

Signed-off-by: Eric Brown <browne@vmware.com>