### PR TITLE
Remove pycryptodome from import blacklist

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -225,7 +225,6 @@ Usage::
       B411  import_xmlrpclib
       B412  import_httpoxy
       B413  import_pycrypto
-      B414  import_pycryptodome
       B501  request_with_no_cert_validation
       B502  ssl_with_bad_version
       B503  ssl_with_bad_defaults

--- a/bandit/blacklists/imports.py
+++ b/bandit/blacklists/imports.py
@@ -202,6 +202,9 @@ library.
 
 B414: import_pycryptodome
 -------------------------
+This import blacklist has been removed. The information here has been
+left for historical purposes.
+
 pycryptodome is a direct fork of pycrypto that has not fully addressed
 the issues inherent in PyCrypto.  It seems to exist, mainly, as an API
 compatible continuation of pycrypto and should be deprecated in favor
@@ -321,20 +324,6 @@ def gen_blacklist():
          'Crypto.Util'],
         'The pyCrypto library and its module {name} are no longer actively '
         'maintained and have been deprecated. '
-        'Consider using pyca/cryptography library.', 'HIGH'))
-
-    sets.append(utils.build_conf_dict(
-        'import_pycryptodome', 'B414',
-        ['Cryptodome.Cipher',
-         'Cryptodome.Hash',
-         'Cryptodome.IO',
-         'Cryptodome.Protocol',
-         'Cryptodome.PublicKey',
-         'Cryptodome.Random',
-         'Cryptodome.Signature',
-         'Cryptodome.Util'],
-        'The pycryptodome library is not considered a secure alternative '
-        'to pycrypto.'
         'Consider using pyca/cryptography library.', 'HIGH'))
 
     return {'Import': sets, 'ImportFrom': sets, 'Call': sets}

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -120,16 +120,16 @@ class FunctionalTests(testtools.TestCase):
     def test_crypto_md5(self):
         '''Test the `hashlib.md5` example.'''
         expect = {
-            'SEVERITY': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 15, 'HIGH': 8},
-            'CONFIDENCE': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 0, 'HIGH': 23}
+            'SEVERITY': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 15, 'HIGH': 4},
+            'CONFIDENCE': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 0, 'HIGH': 19}
         }
         self.check_example('crypto-md5.py', expect)
 
     def test_ciphers(self):
         '''Test the `Crypto.Cipher` example.'''
         expect = {
-            'SEVERITY': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 1, 'HIGH': 26},
-            'CONFIDENCE': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 0, 'HIGH': 27}
+            'SEVERITY': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 1, 'HIGH': 21},
+            'CONFIDENCE': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 0, 'HIGH': 22}
         }
         self.check_example('ciphers.py', expect)
 
@@ -663,8 +663,8 @@ class FunctionalTests(testtools.TestCase):
     def test_weak_cryptographic_key(self):
         '''Test for weak key sizes.'''
         expect = {
-            'SEVERITY': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 8, 'HIGH': 10},
-            'CONFIDENCE': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 0, 'HIGH': 18}
+            'SEVERITY': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 8, 'HIGH': 8},
+            'CONFIDENCE': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 0, 'HIGH': 16}
         }
         self.check_example('weak_cryptographic_key_sizes.py', expect)
 


### PR DESCRIPTION
pycryptodome appears to be actively maintained, as opposed to pycrypto.

Unless there is a noted security issue with not using it, this removes
the blanket blacklist on the library. Any insecure hashes/ciphers/etc.
that the library provides will still be reported as per other libraries.