### PR TITLE
Fix terminal colors not displaying properly on Windows

### DIFF
--- a/bandit/formatters/screen.py
+++ b/bandit/formatters/screen.py
@@ -48,6 +48,17 @@ from bandit.core import constants
 from bandit.core import docs_utils
 from bandit.core import test_properties
 
+# This fixes terminal colors not displaying properly on Windows systems.
+# Colorama will intercept any ANSI escape codes and convert them to the
+# proper Windows console API calls to change text color.
+if sys.platform.startswith('win32'):
+    try:
+        import colorama
+    except ImportError:
+        pass
+    else:
+        colorama.init()
+
 LOG = logging.getLogger(__name__)
 
 COLOR = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ GitPython>=1.0.1 # BSD License (3 clause)
 PyYAML>=3.12 # MIT
 six>=1.10.0 # MIT
 stevedore>=1.20.0 # Apache-2.0
+colorama>=0.3.9;platform_system=="Windows" # BSD License (3 clause)


### PR DESCRIPTION
Currently, text colors do not render if using `bandit` in a Windows terminal interface (both PowerShell and CMD).

Example: 
![bandit_old_bad_colors](https://user-images.githubusercontent.com/6599820/48247259-e07efa00-e3af-11e8-96f6-9a368553746a.PNG)

This PR resolves that issue by patching stdout using `colorama` when running on Windows. Colorama will intercept any ANSI escape codes and convert them to the proper Windows console API calls to change text color (as far as I understand it at least, I'm not a colorama developer). 

Example with the fix applied:
![bandit_new_good_colors](https://user-images.githubusercontent.com/6599820/48247375-51261680-e3b0-11e8-9f29-2d341559befc.PNG)


Caveats: this adds a dependency on `colorama` for Windows. It is a very common dependency for Windows Python programs with a CLI interface, is actively maintained, and is licensed under BSD-3.