### PR TITLE
Add mac os to tested environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
-language: python
-
 cache: pip
 
-sudo: false
+before_install:
+  - ./.travis/install.sh
 
 install:
   - pip install tox
@@ -11,28 +10,66 @@ script: tox
 
 matrix:
   include:
-    - python: 2.7
+    - os: linux
+      language: python
+      python: 2.7
       env: TOXENV=pylint
-    - python: 2.7
+    - os: linux
+      language: python
+      python: 2.7
       env: TOXENV=pep8
-    - python: 2.7
+    - os: linux
+      language: python
+      python: 2.7
       env: TOXENV=py27
-    - python: 3.5
+    - os: osx
+      language: generic
+      python: 2.7
+      env: TOXENV=py27
+    - os: linux
+      language: python
+      python: 3.5
       env: TOXENV=py35
-    - python: 3.6
+    - os: osx
+      language: generic
+      python: 3.5
+      env: TOXENV=py35
+    - os: linux
+      language: python
+      python: 3.6
       env: TOXENV=py36
-    - python: 3.7
+    - os: osx
+      language: generic
+      python: 3.6
+      env: TOXENV=py36
+    - os: linux
+      language: python
+      python: 3.7
       env: TOXENV=py37
       dist: xenial
       sudo: true
-    - python: 3.8-dev
+    - os: osx
+      language: generic
+      python: 3.7
+      env: TOXENV=py37
+    - os: linux
+      language: python
+      python: 3.8-dev
       env: TOXENV=py38
       dist: xenial
       sudo: true
-    - python: pypy
+    - os: linux
+      language: python
+      python: pypy
+      env: TOXENV=pypy
+    - os: osx
+      language: generic
+      python: pypy
       env: TOXENV=pypy
   allow_failures:
-    - python: 3.8-dev
+    - os: linux
+      language: python
+      python: 3.8-dev
       env: TOXENV=py38
       dist: xenial
       sudo: true

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
+    brew update
+    brew upgrade pyenv
+
+    case "${TOXENV}" in
+        py27)
+            pyenv install 2.7
+            pyenv local 2.7
+            ;;
+        py35)
+            pyenv install 3.5.6
+            pyenv local 3.5.6
+            ;;
+        py36)
+            pyenv install 3.6.7
+            pyenv local 3.6.7
+            ;;
+        py37)
+            pyenv install 3.7.1
+            pyenv local 3.7.1
+            ;;
+        pypy)
+            pyenv install pypy3.5-6.0.0
+            pyenv local pypy3.5-6.0.0
+            ;;
+    esac
+
+    brew install pyenv-virtualenv
+
+fi


### PR DESCRIPTION
Currently in the matrix for the Travis CI, only Linux is tested.
Yet according to the module classifier, Linux and macOS are
supported.

This patch adds macOS as a tested enviroment.

Signed-off-by: Eric Brown <browne@vmware.com>