### PR TITLE
Supporting CSafeLoader in yaml.load plugin

### DIFF
--- a/bandit/plugins/yaml_load.py
+++ b/bandit/plugins/yaml_load.py
@@ -63,10 +63,10 @@ def yaml_load(context):
     qualname_list = qualname.split('.')
     func = qualname_list[-1]
     if all([
-        'yaml' in qualname_list,
-        func == 'load',
-        not context.check_call_arg_value('Loader', 'SafeLoader'),
-        not context.check_call_arg_value('Loader', 'CSafeLoader'),
+            'yaml' in qualname_list,
+            func == 'load',
+            not context.check_call_arg_value('Loader', 'SafeLoader'),
+            not context.check_call_arg_value('Loader', 'CSafeLoader'),
     ]):
         return bandit.Issue(
             severity=bandit.MEDIUM,

--- a/examples/yaml_load.py
+++ b/examples/yaml_load.py
@@ -6,7 +6,11 @@ def test_yaml_load():
     ystr = yaml.dump({'a': 1, 'b': 2, 'c': 3})
     y = yaml.load(ystr)
     yaml.dump(y)
-    y = yaml.load(ystr, Loader=yaml.SafeLoader)
+    try:
+        y = yaml.load(ystr, Loader=yaml.CSafeLoader)
+    except AttributeError:
+        # CSafeLoader only exists if you build yaml with LibYAML
+        y = yaml.load(ystr, Loader=yaml.SafeLoader)
 
 
 def test_json_load():


### PR DESCRIPTION
PyYAML also supports `CSafeLoader`. This is used for faster loading, if you have the right libraries installed. This check should not alert off this loader, because it is still safe (just faster).

While I was at it, I also did a bit of minor refactoring, to reduce the number of indents used.