### PR TITLE
Fix ResourceWarning: unclosed file

### DIFF
--- a/bandit/core/config.py
+++ b/bandit/core/config.py
@@ -47,7 +47,8 @@ class BanditConfig(object):
                                         config_file)
 
             try:
-                self._config = yaml.safe_load(f)
+                with f:
+                    self._config = yaml.safe_load(f)
                 self.validate(config_file)
             except yaml.YAMLError as err:
                 LOG.error(err)

--- a/examples/hardcoded-tmp.py
+++ b/examples/hardcoded-tmp.py
@@ -1,21 +1,16 @@
-f = open('/tmp/abc', 'w')
-f.write('def')
-f.close()
+with open('/tmp/abc', 'w') as f:
+    f.write('def')
 
 # ok
-f = open('/abc/tmp', 'w')
-f.write('def')
-f.close()
+with open('/abc/tmp', 'w') as f:
+    f.write('def')
 
-f = open('/var/tmp/123', 'w')
-f.write('def')
-f.close()
+with open('/var/tmp/123', 'w') as f:
+    f.write('def')
 
-f = open('/dev/shm/unit/test', 'w')
-f.write('def')
-f.close()
+with open('/dev/shm/unit/test', 'w') as f:
+    f.write('def')
 
 # Negative test
-f = open('/foo/bar', 'w')
-f.write('def')
-f.close()
+with open('/foo/bar', 'w') as f:
+    f.write('def')

--- a/tests/unit/core/test_manager.py
+++ b/tests/unit/core/test_manager.py
@@ -157,9 +157,9 @@ class ManagerTests(testtools.TestCase):
         conf_level = constants.LOW
         output_filename = os.path.join(temp_directory, "_temp_output")
         output_format = "invalid"
-        tmp_file = open(output_filename, 'w')
-        self.manager.output_results(lines, sev_level, conf_level, tmp_file,
-                                    output_format)
+        with open(output_filename, 'w') as tmp_file:
+            self.manager.output_results(lines, sev_level, conf_level,
+                                        tmp_file, output_format)
         self.assertTrue(os.path.isfile(output_filename))
 
     def test_output_results_valid_format(self):
@@ -170,9 +170,9 @@ class ManagerTests(testtools.TestCase):
         conf_level = constants.LOW
         output_filename = os.path.join(temp_directory, "_temp_output.txt")
         output_format = "txt"
-        tmp_file = open(output_filename, 'w')
-        self.manager.output_results(lines, sev_level, conf_level, tmp_file,
-                                    output_format)
+        with open(output_filename, 'w') as tmp_file:
+            self.manager.output_results(lines, sev_level, conf_level,
+                                        tmp_file, output_format)
         self.assertTrue(os.path.isfile(output_filename))
 
     @mock.patch('os.path.isdir')

--- a/tests/unit/core/test_util.py
+++ b/tests/unit/core/test_util.py
@@ -28,8 +28,7 @@ from bandit.core import utils as b_utils
 
 def _touch(path):
     '''Create an empty file at ``path``.'''
-    newf = open(path, 'w')
-    newf.close()
+    open(path, 'w').close()
 
 
 class UtilTests(testtools.TestCase):
@@ -225,10 +224,10 @@ class UtilTests(testtools.TestCase):
         # self.assertEqual(name, 'a.list[0]')
 
     def test_linerange(self):
-        self.test_file = open("./examples/jinja2_templating.py")
-        self.tree = ast.parse(self.test_file.read())
+        with open("./examples/jinja2_templating.py") as test_file:
+            tree = ast.parse(test_file.read())
         # Check linerange returns corrent number of lines
-        line = self.tree.body[8]
+        line = tree.body[8]
         lrange = b_utils.linerange(line)
 
         # line 9 should be three lines long
@@ -287,9 +286,8 @@ class UtilTests(testtools.TestCase):
 
         with tempfile.NamedTemporaryFile('r+') as t:
             for test in tests:
-                f = open(t.name, 'w')
-                f.write(test['content'])
-                f.close()
+                with open(t.name, 'w') as f:
+                    f.write(test['content'])
 
                 self.assertEqual(b_utils.parse_ini_file(t.name),
                                  test['expected'])

--- a/tests/unit/formatters/test_csv.py
+++ b/tests/unit/formatters/test_csv.py
@@ -48,9 +48,9 @@ class CsvFormatterTests(testtools.TestCase):
         self.manager.results.append(self.issue)
 
     def test_report(self):
-        tmp_file = open(self.tmp_fname, 'w')
-        b_csv.report(self.manager, tmp_file, self.issue.severity,
-                     self.issue.confidence)
+        with open(self.tmp_fname, 'w') as tmp_file:
+            b_csv.report(self.manager, tmp_file, self.issue.severity,
+                         self.issue.confidence)
 
         with open(self.tmp_fname) as f:
             reader = csv.DictReader(f)

--- a/tests/unit/formatters/test_html.py
+++ b/tests/unit/formatters/test_html.py
@@ -41,9 +41,9 @@ class HtmlFormatterTests(testtools.TestCase):
     def test_report_with_skipped(self):
         self.manager.skipped = [('abc.py', 'File is bad')]
 
-        tmp_file = open(self.tmp_fname, 'w')
-        b_html.report(
-            self.manager, tmp_file, bandit.LOW, bandit.LOW)
+        with open(self.tmp_fname, 'w') as tmp_file:
+            b_html.report(
+                self.manager, tmp_file, bandit.LOW, bandit.LOW)
 
         with open(self.tmp_fname) as f:
             soup = bs4.BeautifulSoup(f.read(), 'html.parser')
@@ -78,9 +78,9 @@ class HtmlFormatterTests(testtools.TestCase):
             [(issue_a, [issue_x, issue_y]),
              (issue_b, [issue_x]), (issue_c, [issue_y])])
 
-        tmp_file = open(self.tmp_fname, 'w')
-        b_html.report(
-            self.manager, tmp_file, bandit.LOW, bandit.LOW)
+        with open(self.tmp_fname, 'w') as tmp_file:
+            b_html.report(
+                self.manager, tmp_file, bandit.LOW, bandit.LOW)
 
         with open(self.tmp_fname) as f:
             soup = bs4.BeautifulSoup(f.read(), 'html.parser')
@@ -143,9 +143,9 @@ class HtmlFormatterTests(testtools.TestCase):
 
         get_issue_list.return_value = {issue_a: [issue_x]}
 
-        tmp_file = open(self.tmp_fname, 'w')
-        b_html.report(
-            self.manager, tmp_file, bandit.LOW, bandit.LOW)
+        with open(self.tmp_fname, 'w') as tmp_file:
+            b_html.report(
+                self.manager, tmp_file, bandit.LOW, bandit.LOW)
 
         with open(self.tmp_fname) as f:
             contents = f.read()

--- a/tests/unit/formatters/test_json.py
+++ b/tests/unit/formatters/test_json.py
@@ -75,9 +75,9 @@ class JsonFormatterTests(testtools.TestCase):
         get_issue_list.return_value = collections.OrderedDict(
             [(self.issue, self.candidates)])
 
-        tmp_file = open(self.tmp_fname, 'w')
-        b_json.report(self.manager, tmp_file, self.issue.severity,
-                      self.issue.confidence)
+        with open(self.tmp_fname, 'w') as tmp_file:
+            b_json.report(self.manager, tmp_file, self.issue.severity,
+                          self.issue.confidence)
 
         with open(self.tmp_fname) as f:
             data = json.loads(f.read())

--- a/tests/unit/formatters/test_screen.py
+++ b/tests/unit/formatters/test_screen.py
@@ -82,9 +82,9 @@ class ScreenFormatterTests(testtools.TestCase):
 
         get_issue_list.return_value = collections.OrderedDict()
         with mock.patch('bandit.formatters.screen.do_print') as m:
-            tmp_file = open(self.tmp_fname, 'w')
-            screen.report(self.manager, tmp_file, bandit.LOW, bandit.LOW,
-                          lines=5)
+            with open(self.tmp_fname, 'w') as tmp_file:
+                screen.report(self.manager, tmp_file, bandit.LOW, bandit.LOW,
+                              lines=5)
             self.assertIn('No issues identified.',
                           '\n'.join([str(a) for a in m.call_args]))
 
@@ -121,9 +121,9 @@ class ScreenFormatterTests(testtools.TestCase):
         with mock.patch(output_str_fn) as output_str:
             output_str.return_value = 'ISSUE_OUTPUT_TEXT'
 
-            tmp_file = open(self.tmp_fname, 'w')
-            screen.report(self.manager, tmp_file, bandit.LOW, bandit.LOW,
-                          lines=5)
+            with open(self.tmp_fname, 'w') as tmp_file:
+                screen.report(self.manager, tmp_file, bandit.LOW, bandit.LOW,
+                              lines=5)
 
             calls = [mock.call(issue_a, '', lines=5),
                      mock.call(issue_b, '', lines=5)]
@@ -133,9 +133,9 @@ class ScreenFormatterTests(testtools.TestCase):
         # Validate that we're outputting all of the expected fields and the
         # correct values
         with mock.patch('bandit.formatters.screen.do_print') as m:
-            tmp_file = open(self.tmp_fname, 'w')
-            screen.report(self.manager, tmp_file, bandit.LOW, bandit.LOW,
-                          lines=5)
+            with open(self.tmp_fname, 'w') as tmp_file:
+                screen.report(self.manager, tmp_file, bandit.LOW, bandit.LOW,
+                              lines=5)
 
             data = '\n'.join([str(a) for a in m.call_args[0][0]])
 
@@ -195,9 +195,9 @@ class ScreenFormatterTests(testtools.TestCase):
         with mock.patch(output_str_fn) as output_str:
             output_str.return_value = 'ISSUE_OUTPUT_TEXT'
 
-            tmp_file = open(self.tmp_fname, 'w')
-            screen.report(self.manager, tmp_file, bandit.LOW, bandit.LOW,
-                          lines=5)
+            with open(self.tmp_fname, 'w') as tmp_file:
+                screen.report(self.manager, tmp_file, bandit.LOW, bandit.LOW,
+                              lines=5)
 
             calls = [mock.call(issue_a, '', lines=5),
                      mock.call(issue_b, '', show_code=False,

--- a/tests/unit/formatters/test_text.py
+++ b/tests/unit/formatters/test_text.py
@@ -77,8 +77,9 @@ class TextFormatterTests(testtools.TestCase):
         self.manager.out_file = self.tmp_fname
 
         get_issue_list.return_value = collections.OrderedDict()
-        tmp_file = open(self.tmp_fname, 'w')
-        b_text.report(self.manager, tmp_file, bandit.LOW, bandit.LOW, lines=5)
+        with open(self.tmp_fname, 'w') as tmp_file:
+            b_text.report(self.manager, tmp_file, bandit.LOW, bandit.LOW,
+                          lines=5)
 
         with open(self.tmp_fname) as f:
             data = f.read()
@@ -117,9 +118,9 @@ class TextFormatterTests(testtools.TestCase):
         with mock.patch(output_str_fn) as output_str:
             output_str.return_value = 'ISSUE_OUTPUT_TEXT'
 
-            tmp_file = open(self.tmp_fname, 'w')
-            b_text.report(self.manager, tmp_file, bandit.LOW, bandit.LOW,
-                          lines=5)
+            with open(self.tmp_fname, 'w') as tmp_file:
+                b_text.report(self.manager, tmp_file, bandit.LOW, bandit.LOW,
+                              lines=5)
 
             calls = [mock.call(issue_a, '', lines=5),
                      mock.call(issue_b, '', lines=5)]
@@ -128,9 +129,9 @@ class TextFormatterTests(testtools.TestCase):
 
         # Validate that we're outputting all of the expected fields and the
         # correct values
-        tmp_file = open(self.tmp_fname, 'w')
-        b_text.report(self.manager, tmp_file, bandit.LOW, bandit.LOW,
-                      lines=5)
+        with open(self.tmp_fname, 'w') as tmp_file:
+            b_text.report(self.manager, tmp_file, bandit.LOW, bandit.LOW,
+                          lines=5)
         with open(self.tmp_fname) as f:
             data = f.read()
 
@@ -182,9 +183,9 @@ class TextFormatterTests(testtools.TestCase):
         with mock.patch(output_str_fn) as output_str:
             output_str.return_value = 'ISSUE_OUTPUT_TEXT'
 
-            tmp_file = open(self.tmp_fname, 'w')
-            b_text.report(self.manager, tmp_file, bandit.LOW, bandit.LOW,
-                          lines=5)
+            with open(self.tmp_fname, 'w') as tmp_file:
+                b_text.report(self.manager, tmp_file, bandit.LOW, bandit.LOW,
+                              lines=5)
 
             calls = [mock.call(issue_a, '', lines=5),
                      mock.call(issue_b, '', show_code=False,

--- a/tests/unit/formatters/test_xml.py
+++ b/tests/unit/formatters/test_xml.py
@@ -69,9 +69,9 @@ class XmlFormatterTests(testtools.TestCase):
         return d
 
     def test_report(self):
-        tmp_file = open(self.tmp_fname, 'wb')
-        b_xml.report(self.manager, tmp_file, self.issue.severity,
-                     self.issue.confidence)
+        with open(self.tmp_fname, 'wb') as tmp_file:
+            b_xml.report(self.manager, tmp_file, self.issue.severity,
+                         self.issue.confidence)
 
         with open(self.tmp_fname) as f:
             data = self._xml_to_dict(ET.XML(f.read()))

--- a/tests/unit/formatters/test_yaml.py
+++ b/tests/unit/formatters/test_yaml.py
@@ -75,9 +75,9 @@ class YamlFormatterTests(testtools.TestCase):
         get_issue_list.return_value = collections.OrderedDict(
             [(self.issue, self.candidates)])
 
-        tmp_file = open(self.tmp_fname, 'w')
-        b_json.report(self.manager, tmp_file, self.issue.severity,
-                      self.issue.confidence)
+        with open(self.tmp_fname, 'w') as tmp_file:
+            b_json.report(self.manager, tmp_file, self.issue.severity,
+                          self.issue.confidence)
 
         with open(self.tmp_fname) as f:
             data = yaml.load(f.read())


### PR DESCRIPTION
Also uniformize the usage of the `with` context manager to prevent resource leaks.

Signed-off-by: Mickaël Schoentgen <contact@tiger-222.fr>