### PR TITLE
check if ast.JoinedStr exists before using it

### DIFF
--- a/bandit/plugins/injection_sql.py
+++ b/bandit/plugins/injection_sql.py
@@ -94,7 +94,7 @@ def _evaluate_ast(node):
         statement = node.s
         # Hierarchy for "".format() is Wrapper -> Call -> Attribute -> Str
         wrapper = node.parent.parent.parent
-    elif isinstance(node.parent, ast.JoinedStr):
+    elif hasattr(ast, 'JoinedStr') and isinstance(node.parent, ast.JoinedStr):
         statement = node.s
         wrapper = node.parent.parent
 


### PR DESCRIPTION
This line with `isinstance(..., ast.JoinedStr)` was added in d237448 for #427.

`ast.JoinedStr` is new in Python3.6 (it's f-strings), it does not exist in Pythons below that, so this is an `AttributeError: 'module' object has no attribute 'JoinedStr'` for Python<3.6.

I'm not sure why travis didn't raise this as an issue, I'm not too familiar with the test suite here so let me know if there's a test that can be added for this.