### PR TITLE
Update python documentation links for version 3 counterparts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,7 +175,7 @@ Usage::
         "{relpath:20.20s}: {line:03}: {test_id:^8}: DEFECT: {msg:>20}"
 
         See python documentation for more information about formatting style:
-        https://docs.python.org/3.4/library/string.html
+        https://docs.python.org/3/library/string.html
 
     The following tests were discovered and loaded:
     -----------------------------------------------
@@ -254,10 +254,10 @@ Usage::
 
 Baseline
 --------
-Bandit allows specifying the path of a baseline report to compare against using the base line argument (i.e. ``-b BASELINE`` or ``--baseline BASELINE``). 
+Bandit allows specifying the path of a baseline report to compare against using the base line argument (i.e. ``-b BASELINE`` or ``--baseline BASELINE``).
 
 ::
-  
+
    bandit -b BASELINE
 
 This is useful for ignoring known vulnerabilities that you believe are non-issues (e.g. a cleartext password in a unit test). To generate a baseline report simply run Bandit with the output format set to ``json`` (only JSON-formatted files are accepted as a baseline) and output file path specified:
@@ -469,7 +469,7 @@ References
 
 Bandit docs: https://bandit.readthedocs.io/en/latest/
 
-Python AST module documentation: https://docs.python.org/2/library/ast.html
+Python AST module documentation: https://docs.python.org/3/library/ast.html
 
 Green Tree Snakes - the missing Python AST docs:
 https://greentreesnakes.readthedocs.org/en/latest/

--- a/bandit/blacklists/calls.py
+++ b/bandit/blacklists/calls.py
@@ -309,6 +309,7 @@ using tmpfile() instead.
 
 For further information:
     https://docs.python.org/2.7/library/os.html#os.tempnam
+    https://docs.python.org/3/whatsnew/3.0.html?highlight=tempnam
     https://bugs.python.org/issue17880
 
 +------+---------------------+------------------------------------+-----------+

--- a/bandit/core/constants.py
+++ b/bandit/core/constants.py
@@ -35,7 +35,7 @@ CONFIDENCE_DEFAULT = 'UNDEFINED'
 # We don't handle the case of user-defined classes being false.
 # These are only useful when we have a constant in code. If we
 # have a variable we cannot determine if False.
-# See https://docs.python.org/2/library/stdtypes.html#truth-value-testing
+# See https://docs.python.org/3/library/stdtypes.html#truth-value-testing
 FALSE_VALUES = [None, False, 'False', 0, 0.0, 0j, '', (), [], {}]
 
 # override with "log_format" option in config file

--- a/bandit/plugins/asserts.py
+++ b/bandit/plugins/asserts.py
@@ -26,7 +26,7 @@ producing \*.pyo files). This caused various protections to be removed. The use
 of assert is also considered as general bad practice in OpenStack codebases.
 
 Please see
-https://docs.python.org/2/reference/simple_stmts.html#the-assert-statement for
+https://docs.python.org/3/reference/simple_stmts.html#the-assert-statement for
 more info on ``assert``
 
 :Example:
@@ -44,7 +44,7 @@ more info on ``assert``
 
  - https://bugs.launchpad.net/juniperopenstack/+bug/1456193
  - https://bugs.launchpad.net/heat/+bug/1397883
- - https://docs.python.org/2/reference/simple_stmts.html#the-assert-statement
+ - https://docs.python.org/3/reference/simple_stmts.html#the-assert-statement
 
 .. versionadded:: 0.11.0
 

--- a/bandit/plugins/exec.py
+++ b/bandit/plugins/exec.py
@@ -34,7 +34,8 @@ Python docs succinctly describe why the use of `exec` is risky.
 
 .. seealso::
 
- - https://docs.python.org/2.0/ref/exec.html
+ - https://docs.python.org/2/reference/simple_stmts.html#exec
+ - https://docs.python.org/3/library/functions.html#exec
  - https://www.python.org/dev/peps/pep-0551/#background
  - https://www.python.org/dev/peps/pep-0578/#suggested-audit-hook-locations
 

--- a/bandit/plugins/injection_shell.py
+++ b/bandit/plugins/injection_shell.py
@@ -196,7 +196,7 @@ def subprocess_popen_with_shell_equals_true(context, config):
     .. seealso::
 
      - https://security.openstack.org
-     - https://docs.python.org/2/library/subprocess.html#frequently-used-arguments  # noqa
+     - https://docs.python.org/3/library/subprocess.html#frequently-used-arguments  # noqa
      - https://security.openstack.org/guidelines/dg_use-subprocess-securely.html
      - https://security.openstack.org/guidelines/dg_avoid-shell-true.html
 
@@ -287,7 +287,7 @@ def subprocess_without_shell_equals_true(context, config):
     .. seealso::
 
      - https://security.openstack.org
-     - https://docs.python.org/2/library/subprocess.html#frequently-used-arguments  # noqa
+     - https://docs.python.org/3/library/subprocess.html#frequently-used-arguments  # noqa
      - https://security.openstack.org/guidelines/dg_avoid-shell-true.html
      - https://security.openstack.org/guidelines/dg_use-subprocess-securely.html
 
@@ -449,8 +449,8 @@ def start_process_with_a_shell(context, config):
     .. seealso::
 
      - https://security.openstack.org
-     - https://docs.python.org/2/library/os.html#os.system
-     - https://docs.python.org/2/library/subprocess.html#frequently-used-arguments  # noqa
+     - https://docs.python.org/3/library/os.html#os.system
+     - https://docs.python.org/3/library/subprocess.html#frequently-used-arguments  # noqa
      - https://security.openstack.org/guidelines/dg_use-subprocess-securely.html
 
     .. versionadded:: 0.10.0
@@ -547,8 +547,8 @@ def start_process_with_no_shell(context, config):
     .. seealso::
 
      - https://security.openstack.org
-     - https://docs.python.org/2/library/os.html#os.system
-     - https://docs.python.org/2/library/subprocess.html#frequently-used-arguments  # noqa
+     - https://docs.python.org/3/library/os.html#os.system
+     - https://docs.python.org/3/library/subprocess.html#frequently-used-arguments  # noqa
      - https://security.openstack.org/guidelines/dg_use-subprocess-securely.html
 
     .. versionadded:: 0.10.0
@@ -633,7 +633,7 @@ def start_process_with_partial_path(context, config):
     .. seealso::
 
      - https://security.openstack.org
-     - https://docs.python.org/2/library/os.html#process-management
+     - https://docs.python.org/3/library/os.html#process-management
 
     .. versionadded:: 0.13.0
     """

--- a/doc/source/man/bandit.rst
+++ b/doc/source/man/bandit.rst
@@ -91,7 +91,7 @@ Example usage:
     "{relpath:20.20s}: {line:03}: {test_id:^8}: DEFECT: {msg:>20}"
 
     See python documentation for more information about formatting style:
-    https://docs.python.org/3.4/library/string.html
+    https://docs.python.org/3/library/string.html
 
 FILES
 =====


### PR DESCRIPTION
The python 2 links are kept when in make sense.