### PR TITLE
Update the docs copyright year

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -35,7 +35,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Bandit'
-copyright = u'2016, Bandit Developers'
+copyright = u'2019, Bandit Developers'
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 add_function_parentheses = True


### PR DESCRIPTION
2016 is way old. It's now 2019 and our docs should reflect a
current year.

Signed-off-by: Eric Brown <browne@vmware.com>