### PR TITLE
Fix #490 -- Fix performance issue introduced in 1.6.0

### DIFF
--- a/bandit/formatters/text.py
+++ b/bandit/formatters/text.py
@@ -141,9 +141,8 @@ def report(manager, fileobj, sev_level, conf_level, lines=-1):
     """
 
     bits = []
-    issues = manager.get_issue_list(sev_level, conf_level)
 
-    if len(issues) or not manager.quiet:
+    if not manager.quiet:
         bits.append("Run started:%s" % datetime.datetime.utcnow())
 
         if manager.verbose:


### PR DESCRIPTION
The lines were introduced in 7c4b9fa8b8d980a27c53000eb1961d436da7b223
and have two effects. First they cause `get_issue_list` to run twice and before
the user receives feedback that bandit started running. Secondly it does not
display any output if no issues are found, which is an unintended behavior change.