### PR TITLE
Remove obsolete "sudo" keyword.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 
 cache: pip
 
-sudo: false
-
 install:
   - pip install tox
 
@@ -24,11 +22,9 @@ matrix:
     - python: 3.7
       env: TOXENV=py37
       dist: xenial
-      sudo: true
     - python: 3.8-dev
       env: TOXENV=py38
       dist: xenial
-      sudo: true
     - python: pypy
       env: TOXENV=pypy
 notifications:


### PR DESCRIPTION
cf. https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

modified:   .travis.yml