### PR TITLE
Remove unused bindep.txt file

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,2 +1,0 @@
-# This is a cross-platform list tracking distribution packages needed by tests;
-# see http://docs.openstack.org/infra/bindep/ for additional information.


### PR DESCRIPTION
This is another file leftover from the OpenStack ecosystem. No
need for it now.

Signed-off-by: Eric Brown <browne@vmware.com>