### PR TITLE
Add shelve to the pickle blacklists

### DIFF
--- a/bandit/blacklists/calls.py
+++ b/bandit/blacklists/calls.py
@@ -42,6 +42,8 @@ deserialize untrusted data, possible security issue.
 |      |                     | - dill.loads                       |           |
 |      |                     | - dill.load                        |           |
 |      |                     | - dill.Unpickler                   |           |
+|      |                     | - shelve.open                      |           |
+|      |                     | - shelve.DbfilenameShelf           |           |
 +------+---------------------+------------------------------------+-----------+
 
 B302: marshal
@@ -347,7 +349,9 @@ def gen_blacklist():
          'cPickle.Unpickler',
          'dill.loads',
          'dill.load',
-         'dill.Unpickler'],
+         'dill.Unpickler',
+         'shelve.open',
+         'shelve.DbfilenameShelf'],
         'Pickle and modules that wrap it can be unsafe when used to '
         'deserialize untrusted data, possible security issue.'
         ))

--- a/bandit/blacklists/imports.py
+++ b/bandit/blacklists/imports.py
@@ -60,6 +60,7 @@ Consider possible security implications associated with these modules.
 | B403 | import_pickle       | - pickle                           | low       |
 |      |                     | - cPickle                          |           |
 |      |                     | - dill                             |           |
+|      |                     | - shelve                           |           |
 +------+---------------------+------------------------------------+-----------+
 
 B404: import_subprocess
@@ -256,7 +257,7 @@ def gen_blacklist():
         ))
 
     sets.append(utils.build_conf_dict(
-        'import_pickle', 'B403', ['pickle', 'cPickle', 'dill'],
+        'import_pickle', 'B403', ['pickle', 'cPickle', 'dill', 'shelve'],
         'Consider possible security implications associated with '
         '{name} module.', 'LOW'
         ))

--- a/examples/shelve_open.py
+++ b/examples/shelve_open.py
@@ -1,0 +1,12 @@
+import os
+import shelve
+import tempfile
+
+with tempfile.TemporaryDirectory() as d:
+    filename = os.path.join(d, 'shelf')
+
+    with shelve.open(filename) as db:
+        db['spam'] = {'eggs': 'ham'}
+
+    with shelve.open(filename) as db:
+        print(db['spam'])

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -363,6 +363,14 @@ class FunctionalTests(testtools.TestCase):
         }
         self.check_example('dill.py', expect)
 
+    def test_shelve(self):
+        '''Test for the `shelve` module.'''
+        expect = {
+            'SEVERITY': {'UNDEFINED': 0, 'LOW': 1, 'MEDIUM': 2, 'HIGH': 0},
+            'CONFIDENCE': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 0, 'HIGH': 3}
+        }
+        self.check_example('shelve_open.py', expect)
+
     def test_popen_wrappers(self):
         '''Test the `popen2` and `commands` modules.'''
         expect = {


### PR DESCRIPTION
shelve is a stdlib module that wraps pickle in a dict-like interface.