### PR TITLE
 Ignore common directories by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,9 +143,11 @@ Usage::
                             only show output in the case of an error
       --ignore-nosec        do not skip lines with # nosec comments
       -x EXCLUDED_PATHS, --exclude EXCLUDED_PATHS
-                            comma-separated list of paths (glob patterns supported)
-                            to exclude from scan (note that these are in addition
-                            to the excluded paths provided in the config file)
+                            comma-separated list of paths (glob patterns
+                            supported) to exclude from scan (note that these are
+                            in addition to the excluded paths provided in the
+                            config file) (default:
+                            .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg)
       -b BASELINE, --baseline BASELINE
                             path of a baseline report to compare against (only
                             JSON-formatted files are accepted)

--- a/bandit/cli/main.py
+++ b/bandit/cli/main.py
@@ -233,10 +233,12 @@ def main():
     )
     parser.add_argument(
         '-x', '--exclude', dest='excluded_paths', action='store',
-        default='', help='comma-separated list of paths (glob patterns '
-                         'supported) to exclude from scan '
-                         '(note that these are in addition to the excluded '
-                         'paths provided in the config file)'
+        default=','.join(constants.EXCLUDE),
+        help='comma-separated list of paths (glob patterns '
+             'supported) to exclude from scan '
+             '(note that these are in addition to the excluded '
+             'paths provided in the config file) (default: ' +
+        ','.join(constants.EXCLUDE) + ')'
     )
     parser.add_argument(
         '-b', '--baseline', dest='baseline', action='store',

--- a/bandit/core/constants.py
+++ b/bandit/core/constants.py
@@ -40,3 +40,16 @@ FALSE_VALUES = [None, False, 'False', 0, 0.0, 0j, '', (), [], {}]
 
 # override with "log_format" option in config file
 log_format_string = '[%(module)s]\t%(levelname)s\t%(message)s'
+
+# Directories to exclude by default
+EXCLUDE = (
+    ".svn",
+    "CVS",
+    ".bzr",
+    ".hg",
+    ".git",
+    "__pycache__",
+    ".tox",
+    ".eggs",
+    "*.egg",
+)

--- a/doc/source/man/bandit.rst
+++ b/doc/source/man/bandit.rst
@@ -8,10 +8,10 @@ SYNOPSIS
 bandit [-h] [-r] [-a {file,vuln}] [-n CONTEXT_LINES] [-c CONFIG_FILE]
             [-p PROFILE] [-t TESTS] [-s SKIPS] [-l] [-i]
             [-f {csv,custom,html,json,screen,txt,xml,yaml}]
-            [--msg-template MSG_TEMPLATE] [-o OUTPUT_FILE] [-v] [-d] [-q]
+            [--msg-template MSG_TEMPLATE] [-o [OUTPUT_FILE]] [-v] [-d] [-q]
             [--ignore-nosec] [-x EXCLUDED_PATHS] [-b BASELINE]
             [--ini INI_PATH] [--exit-zero] [--version]
-            targets [targets ...]
+            [targets [targets ...]]
 
 DESCRIPTION
 ===========
@@ -59,9 +59,11 @@ OPTIONS
                         only show output in the case of an error
   --ignore-nosec        do not skip lines with # nosec comments
   -x EXCLUDED_PATHS, --exclude EXCLUDED_PATHS
-                        comma-separated list of paths (glob patterns supported)
-                        to exclude from scan (note that these are in addition
-                        to the excluded paths provided in the config file)
+                        comma-separated list of paths (glob patterns
+                        supported) to exclude from scan (note that these are
+                        in addition to the excluded paths provided in the
+                        config file) (default:
+                        .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg)
   -b BASELINE, --baseline BASELINE
                         path of a baseline report to compare against (only
                         JSON-formatted files are accepted)


### PR DESCRIPTION
This fix follows the example of flake8 in that it sets a default
list of common directories and filename patterns to exclude.
Fixes #543

Signed-off-by: Eric Brown <browne@vmware.com>