### PR TITLE
Add official support of Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     - python: 3.7
       env: TOXENV=py37
       dist: xenial
-    - python: 3.8-dev
+    - python: 3.8
       env: TOXENV=py38
       dist: xenial
     - python: pypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifier =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Topic :: Security
 
 [entry_points]


### PR DESCRIPTION
Now that Python 3.8 is released and Bandit is fully tested against
it, we can officially claim support of it.

https://www.python.org/downloads/release/python-380/

Signed-off-by: Eric Brown <browne@vmware.com>