### PR TITLE
Fix for issues 275, 466 (baseline issue freq increase)

### DIFF
--- a/bandit/core/issue.py
+++ b/bandit/core/issue.py
@@ -20,6 +20,7 @@ from __future__ import unicode_literals
 import linecache
 
 from six import moves
+from collections import Counter
 
 from bandit.core import constants
 
@@ -132,6 +133,26 @@ class Issue(object):
         self.lineno = data["line_number"]
         self.linerange = data["line_range"]
 
+class HashableIssue:
+    '''A hashable issue class to allow us to do comparisions between
+    different issues/count the frequency using a Collection Counter
+
+    '''
+    def __init__(self, issue):
+        self.issue = issue
+
+    def __hash__(self):
+        issue_hash = 0
+        for prop in ['text', 'severity', 'confidence', 'fname', 'test',
+                       'test_id']:
+            issue_hash ^= hash(self.issue.__dict__[prop])
+        return issue_hash
+
+    def __eq__(self, other):
+        return (self.issue.__eq__(other.issue))
+
+    def convert_issues_hashable(issues):
+        return Counter([HashableIssue(issue) for issue in issues])
 
 def issue_from_dict(data):
     i = Issue(severity=data["issue_severity"])

--- a/bandit/core/manager.py
+++ b/bandit/core/manager.py
@@ -384,14 +384,21 @@ def _compare_baseline_results(baseline, results):
     """Compare a baseline list of issues to list of results
 
     This function compares a baseline set of issues to a current set of issues
-    to find results that weren't present in the baseline.
+    to find results that weren't present in the baseline. If the frequency of 
+    an issue increases above the baseline, this will also be returned.
 
     :param baseline: Baseline list of issues
     :param results: Current list of issues
     :return: List of unmatched issues
     """
-    return [a for a in results if a not in baseline]
 
+    hashable_results = issue.HashableIssue.convert_issues_hashable(results)
+    hashable_baseline = issue.HashableIssue.convert_issues_hashable(baseline)
+    hashable_results.subtract(hashable_baseline)
+
+    # For any issue where the count is < 0, either its a new issue or the
+    # count has gone up, so return the issue
+    return [k.issue for k,v in hashable_results.items() if v > 0]
 
 def _find_candidate_matches(unmatched_issues, results_list):
     """Returns a dictionary with issue candidates


### PR DESCRIPTION
Baseline scanning is now able to recognise when the frequency of an
existing issue increases within a file and will then report back
all instances of that issue.

Specifically addressing:
https://github.com/PyCQA/bandit/issues/275
https://github.com/PyCQA/bandit/issues/466