### PR TITLE
Add push and pull request to GH Action trigger

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,6 @@
 name: Build and Test Bandit
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   pylint:


### PR DESCRIPTION
It appears that Actions are not triggered for all pull requests.
I suspect the Actions need to register for event push and pull_request
in order to run CI on commits.

Signed-off-by: Eric Brown <browne@vmware.com>