### PR TITLE
[DOC] Support python3 venv creation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,10 @@ Bandit is distributed on PyPI. The best way to install it is with pip:
 Create a virtual environment (optional)::
 
     virtualenv bandit-env
+    # Or if you're working with a Python 3 project
+    python3 -m venv bandit-env
+    # And activate it:
+    source bandit-venv/bin/activate
 
 Install Bandit::
 


### PR DESCRIPTION
In python3 there is no `virtualenv`. python2 is EOL. The venv directive should consider python3 first.