### PR TITLE
Disable individual tests

### DIFF
--- a/bandit/core/manager.py
+++ b/bandit/core/manager.py
@@ -493,7 +493,7 @@ def _parse_nosec_comment(comment):
     if nosec_tests:
         extman = extension_loader.MANAGER
         # lookup tests by short code or name
-        for test in re.finditer(NOSEC_COMMENT_TESTS, nosec_tests):
+        for test in NOSEC_COMMENT_TESTS.finditer(nosec_tests):
             test_match = test.group(1)
             test_id = _find_test_id_from_nosec_string(extman, test_match)
             if test_id:

--- a/bandit/core/metrics.py
+++ b/bandit/core/metrics.py
@@ -19,8 +19,12 @@ class Metrics:
 
     def __init__(self):
         self.data = dict()
-        self.data["_totals"] = {"loc": 0, "nosec": 0, "nosec_by_test": 0,
-                                "failed_nosec_by_test": 0}
+        self.data["_totals"] = {
+            "loc": 0,
+            "nosec": 0,
+            "nosec_by_test": 0,
+            "failed_nosec_by_test": 0,
+        }
 
         # initialize 0 totals for criteria and rank; this will be reset later
         for rank in constants.RANKING:
@@ -33,8 +37,12 @@ class Metrics:
         This starts a new metric collection name "fname" and makes is active.
         :param fname: the metrics unique name, normally the file name.
         """
-        self.data[fname] = {"loc": 0, "nosec": 0, "nosec_by_test": 0,
-                            "failed_nosec_by_test": 0}
+        self.data[fname] = {
+            "loc": 0,
+            "nosec": 0,
+            "nosec_by_test": 0,
+            "failed_nosec_by_test": 0,
+        }
         self.current = self.data[fname]
 
     def note_nosec(self, num=1):
@@ -54,8 +62,9 @@ class Metrics:
         self.current["nosec_by_test"] += num
 
     def note_failed_nosec_by_test(self, num=1):
-        """Note a test failed not caught when specific tests in comment used
+        """Note a test failed when using a nosec comment with specific tests.
 
+        e.g. # nosec B102, B607, but B602 failed.
         Increment the currently active metrics failed_nosec_by_test count.
         :param num: number of failed nosecs seen, defaults to 1
         """

--- a/bandit/core/metrics.py
+++ b/bandit/core/metrics.py
@@ -19,7 +19,8 @@ class Metrics:
 
     def __init__(self):
         self.data = dict()
-        self.data["_totals"] = {"loc": 0, "nosec": 0}
+        self.data["_totals"] = {"loc": 0, "nosec": 0, "nosec_by_test": 0,
+                                "failed_nosec_by_test": 0}
 
         # initialize 0 totals for criteria and rank; this will be reset later
         for rank in constants.RANKING:
@@ -30,20 +31,35 @@ class Metrics:
         """Begin a new metric block.
 
         This starts a new metric collection name "fname" and makes is active.
-
         :param fname: the metrics unique name, normally the file name.
         """
-        self.data[fname] = {"loc": 0, "nosec": 0}
+        self.data[fname] = {"loc": 0, "nosec": 0, "nosec_by_test": 0,
+                            "failed_nosec_by_test": 0}
         self.current = self.data[fname]
 
     def note_nosec(self, num=1):
-        """Note a "nosec" commnet.
+        """Note a "nosec" comment.
 
         Increment the currently active metrics nosec count.
-
         :param num: number of nosecs seen, defaults to 1
         """
         self.current["nosec"] += num
+
+    def note_nosec_by_test(self, num=1):
+        """Note a "nosec BXXX, BYYY, ..." comment.
+
+        Increment the currently active metrics nosec_by_test count.
+        :param num: number of nosecs seen, defaults to 1
+        """
+        self.current["nosec_by_test"] += num
+
+    def note_failed_nosec_by_test(self, num=1):
+        """Note a test failed not caught when specific tests in comment used
+
+        Increment the currently active metrics failed_nosec_by_test count.
+        :param num: number of failed nosecs seen, defaults to 1
+        """
+        self.current["failed_nosec_by_test"] += num
 
     def count_locs(self, lines):
         """Count lines of code.

--- a/bandit/core/metrics.py
+++ b/bandit/core/metrics.py
@@ -22,8 +22,7 @@ class Metrics:
         self.data["_totals"] = {
             "loc": 0,
             "nosec": 0,
-            "nosec_by_test": 0,
-            "failed_nosec_by_test": 0,
+            "skipped_tests": 0,
         }
 
         # initialize 0 totals for criteria and rank; this will be reset later
@@ -40,8 +39,7 @@ class Metrics:
         self.data[fname] = {
             "loc": 0,
             "nosec": 0,
-            "nosec_by_test": 0,
-            "failed_nosec_by_test": 0,
+            "skipped_tests": 0,
         }
         self.current = self.data[fname]
 
@@ -53,22 +51,13 @@ class Metrics:
         """
         self.current["nosec"] += num
 
-    def note_nosec_by_test(self, num=1):
+    def note_skipped_test(self, num=1):
         """Note a "nosec BXXX, BYYY, ..." comment.
 
-        Increment the currently active metrics nosec_by_test count.
-        :param num: number of nosecs seen, defaults to 1
+        Increment the currently active metrics skipped_tests count.
+        :param num: number of skipped_tests seen, defaults to 1
         """
-        self.current["nosec_by_test"] += num
-
-    def note_failed_nosec_by_test(self, num=1):
-        """Note a test failed when using a nosec comment with specific tests.
-
-        e.g. # nosec B102, B607, but B602 failed.
-        Increment the currently active metrics failed_nosec_by_test count.
-        :param num: number of failed nosecs seen, defaults to 1
-        """
-        self.current["failed_nosec_by_test"] += num
+        self.current["skipped_tests"] += num
 
     def count_locs(self, lines):
         """Count lines of code.

--- a/bandit/core/node_visitor.py
+++ b/bandit/core/node_visitor.py
@@ -30,7 +30,7 @@ class BanditNodeVisitor:
         self.imports = set()
         self.import_aliases = {}
         self.tester = b_tester.BanditTester(
-            self.testset, self.debug, nosec_lines
+            self.testset, self.debug, nosec_lines, metrics
         )
 
         # in some cases we can't determine a qualified name
@@ -207,6 +207,7 @@ class BanditNodeVisitor:
                 LOG.debug("skipped, nosec without test number")
                 self.metrics.note_nosec()
                 return False
+
         if hasattr(node, "col_offset"):
             self.context["col_offset"] = node.col_offset
 
@@ -275,12 +276,6 @@ class BanditNodeVisitor:
         severity, this is needed to update the stored list.
         :param score: The score list to update our scores with
         """
-        # scores has extra nosec information about nosecs with specific tests
-        # so pop those out first and track the metrics for them
-        self.metrics.note_nosec_by_test(scores.pop("nosecs_by_tests"))
-        self.metrics.note_failed_nosec_by_test(
-            scores.pop("failed_nosecs_by_test")
-        )
         # we'll end up with something like:
         # SEVERITY: {0, 0, 0, 10}  where 10 is weighted by finding and level
         for score_type in self.scores:

--- a/bandit/core/node_visitor.py
+++ b/bandit/core/node_visitor.py
@@ -201,8 +201,10 @@ class BanditNodeVisitor:
         if hasattr(node, "lineno"):
             self.context["lineno"] = node.lineno
 
-            if node.lineno in self.nosec_lines:
-                LOG.debug("skipped, nosec")
+            # explicitly check for empty set to skip all tests for a line
+            nosec_tests = self.nosec_lines.get(node.lineno)
+            if nosec_tests is not None and not len(nosec_tests):
+                LOG.debug("skipped, nosec without test number")
                 self.metrics.note_nosec()
                 return False
         if hasattr(node, "col_offset"):
@@ -273,6 +275,12 @@ class BanditNodeVisitor:
         severity, this is needed to update the stored list.
         :param score: The score list to update our scores with
         """
+        # scores has extra nosec information about nosecs with specific tests
+        # so pop those out first and track the metrics for them
+        self.metrics.note_nosec_by_test(scores.pop("nosecs_by_tests"))
+        self.metrics.note_failed_nosec_by_test(
+            scores.pop("failed_nosecs_by_test")
+        )
         # we'll end up with something like:
         # SEVERITY: {0, 0, 0, 10}  where 10 is weighted by finding and level
         for score_type in self.scores:

--- a/bandit/core/tester.py
+++ b/bandit/core/tester.py
@@ -38,7 +38,7 @@ class BanditTester:
             "SEVERITY": [0] * len(constants.RANKING),
             "CONFIDENCE": [0] * len(constants.RANKING),
             "nosecs_by_tests": 0,
-            "failed_nosecs_by_test": 0
+            "failed_nosecs_by_test": 0,
         }
 
         tests = self.testset.get_tests(checktype)
@@ -57,7 +57,8 @@ class BanditTester:
                     nosec_tests_to_skip = set()
                     base_tests = self.nosec_lines.get(result.lineno, None)
                     context_tests = self.nosec_lines.get(
-                        temp_context["lineno"], None)
+                        temp_context["lineno"], None
+                    )
 
                     # if both are non there are were no comments
                     # this is explicitly different than being empty
@@ -90,19 +91,23 @@ class BanditTester:
                         # if the set is empty or the test id is in the set of
                         # tests to skip, log and increment the skip by test
                         # count
-                        if not nosec_tests_to_skip or \
-                                (result.test_id in nosec_tests_to_skip):
-                            LOG.debug("skipped, nosec for test %s"
-                                      % result.test_id)
-                            scores['nosecs_by_tests'] += 1
+                        if not nosec_tests_to_skip or (
+                            result.test_id in nosec_tests_to_skip
+                        ):
+                            LOG.debug(
+                                "skipped, nosec for test %s" % result.test_id
+                            )
+                            scores["nosecs_by_tests"] += 1
                             continue
                         # otherwise this test was not called out explicitly by
                         # a nosec BXX type comment and should fail. Log and
                         # increment the failed test count
                         else:
-                            LOG.debug("uncaught test %s in nosec comment"
-                                      % result.test_id)
-                            scores['failed_nosecs_by_test'] += 1
+                            LOG.debug(
+                                "uncaught test %s in nosec comment"
+                                % result.test_id
+                            )
+                            scores["failed_nosecs_by_test"] += 1
 
                     self.results.append(result)
 

--- a/bandit/core/tester.py
+++ b/bandit/core/tester.py
@@ -15,12 +15,13 @@ LOG = logging.getLogger(__name__)
 
 
 class BanditTester:
-    def __init__(self, testset, debug, nosec_lines):
+    def __init__(self, testset, debug, nosec_lines, metrics):
         self.results = []
         self.testset = testset
         self.last_result = None
         self.debug = debug
         self.nosec_lines = nosec_lines
+        self.metrics = metrics
 
     def run_tests(self, raw_context, checktype):
         """Runs all tests for a certain type of check, for example
@@ -37,8 +38,6 @@ class BanditTester:
         scores = {
             "SEVERITY": [0] * len(constants.RANKING),
             "CONFIDENCE": [0] * len(constants.RANKING),
-            "nosecs_by_tests": 0,
-            "failed_nosecs_by_test": 0,
         }
 
         tests = self.testset.get_tests(checktype)
@@ -54,24 +53,9 @@ class BanditTester:
                     result = test(context)
 
                 if result is not None:
-                    nosec_tests_to_skip = set()
-                    base_tests = self.nosec_lines.get(result.lineno, None)
-                    context_tests = self.nosec_lines.get(
-                        temp_context["lineno"], None
+                    nosec_tests_to_skip = self._get_nosecs_from_contexts(
+                        temp_context, test_result=result
                     )
-
-                    # if both are non there are were no comments
-                    # this is explicitly different than being empty
-                    # empty set indicates blanket nosec comment without
-                    # individual test names or ids
-                    if base_tests is None and context_tests is None:
-                        nosec_tests_to_skip = None
-
-                    # combine tests from current line and context line
-                    if base_tests is not None:
-                        nosec_tests_to_skip.update(base_tests)
-                    if context_tests is not None:
-                        nosec_tests_to_skip.update(context_tests)
 
                     if isinstance(temp_context["filename"], bytes):
                         result.fname = temp_context["filename"].decode("utf-8")
@@ -86,7 +70,7 @@ class BanditTester:
                     if result.test_id == "":
                         result.test_id = test._test_id
 
-                    # don't skip a the test if there was no nosec comment
+                    # don't skip the test if there was no nosec comment
                     if nosec_tests_to_skip is not None:
                         # if the set is empty or the test id is in the set of
                         # tests to skip, log and increment the skip by test
@@ -97,17 +81,8 @@ class BanditTester:
                             LOG.debug(
                                 "skipped, nosec for test %s" % result.test_id
                             )
-                            scores["nosecs_by_tests"] += 1
+                            self.metrics.note_skipped_test()
                             continue
-                        # otherwise this test was not called out explicitly by
-                        # a nosec BXX type comment and should fail. Log and
-                        # increment the failed test count
-                        else:
-                            LOG.debug(
-                                "uncaught test %s in nosec comment"
-                                % result.test_id
-                            )
-                            scores["failed_nosecs_by_test"] += 1
 
                     self.results.append(result)
 
@@ -118,6 +93,18 @@ class BanditTester:
                     con = constants.RANKING.index(result.confidence)
                     val = constants.RANKING_VALUES[result.confidence]
                     scores["CONFIDENCE"][con] += val
+                else:
+                    nosec_tests_to_skip = self._get_nosecs_from_contexts(
+                        temp_context
+                    )
+                    if (
+                        nosec_tests_to_skip
+                        and test._test_id in nosec_tests_to_skip
+                    ):
+                        LOG.warning(
+                            f"nosec encountered ({test._test_id}), but no "
+                            f"failed test on line {temp_context['lineno']}"
+                        )
 
             except Exception as e:
                 self.report_error(name, context, e)
@@ -125,6 +112,35 @@ class BanditTester:
                     raise
         LOG.debug("Returning scores: %s", scores)
         return scores
+
+    def _get_nosecs_from_contexts(self, context, test_result=None):
+        """Use context and optional test result to get set of tests to skip.
+        :param context: temp context
+        :param test_result: optional test result
+        :return: set of tests to skip for the line based on contexts
+        """
+        nosec_tests_to_skip = set()
+        base_tests = (
+            self.nosec_lines.get(test_result.lineno, None)
+            if test_result
+            else None
+        )
+        context_tests = self.nosec_lines.get(context["lineno"], None)
+
+        # if both are none there were no comments
+        # this is explicitly different from being empty.
+        # empty set indicates blanket nosec comment without
+        # individual test names or ids
+        if base_tests is None and context_tests is None:
+            nosec_tests_to_skip = None
+
+        # combine tests from current line and context line
+        if base_tests is not None:
+            nosec_tests_to_skip.update(base_tests)
+        if context_tests is not None:
+            nosec_tests_to_skip.update(context_tests)
+
+        return nosec_tests_to_skip
 
     @staticmethod
     def report_error(test, context, error):

--- a/bandit/formatters/text.py
+++ b/bandit/formatters/text.py
@@ -171,6 +171,14 @@ def report(manager, fileobj, sev_level, conf_level, lines=-1):
             "\tTotal lines skipped (#nosec): %i"
             % (manager.metrics.data["_totals"]["nosec"])
         )
+        bits.append(
+            "\tTotal lines skipped (#nosec BXXX,BYYY,...): %i"
+            % (manager.metrics.data["_totals"]["nosec_by_test"])
+        )
+        bits.append(
+            "\tTotal other nosec test caught (#nosec BXXX,BYYY but BZZZ): %i"
+            % (manager.metrics.data["_totals"]["failed_nosec_by_test"])
+        )
 
         skipped = manager.get_skipped()
         bits.append(get_metrics(manager))

--- a/bandit/formatters/text.py
+++ b/bandit/formatters/text.py
@@ -172,12 +172,9 @@ def report(manager, fileobj, sev_level, conf_level, lines=-1):
             % (manager.metrics.data["_totals"]["nosec"])
         )
         bits.append(
-            "\tTotal lines skipped (#nosec BXXX,BYYY,...): %i"
-            % (manager.metrics.data["_totals"]["nosec_by_test"])
-        )
-        bits.append(
-            "\tTotal other nosec test caught (#nosec BXXX,BYYY but BZZZ): %i"
-            % (manager.metrics.data["_totals"]["failed_nosec_by_test"])
+            "\tTotal potential issues skipped due to specifically being "
+            "disabled (e.g., #nosec BXXX): %i"
+            % (manager.metrics.data["_totals"]["skipped_tests"])
         )
 
         skipped = manager.get_skipped()

--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -41,6 +41,23 @@ security issue, it will not be reported::
 
     self.process = subprocess.Popen('/bin/echo', shell=True)  # nosec
 
+Because multiple issues can be reported for the same line, specific tests may
+be provided to suppress those reports. This will cause other issues not
+included to be reported. This can be useful in preventing situations where a
+nosec comment is used, but a separate vulnerability may be added to the line
+later causing the new vulnerability to be ignored.
+
+For example, this will suppress the report of B602 and B607::
+
+    self.process = subprocess.Popen('/bin/ls *', shell=True)  #nosec B602, B607
+
+Full test names rather than the test ID may also be used.
+
+For example, this will suppress the report of B101 and continue to report B506
+as an issue.::
+
+    assert yaml.load("{}") == []  # nosec assert_used
+
 -----------------
 Scanning Behavior
 -----------------

--- a/examples/nosec.py
+++ b/examples/nosec.py
@@ -5,3 +5,10 @@ subprocess.Popen('/bin/ls *',
                  shell=True)  #nosec (on the specific kwarg line)
 subprocess.Popen('#nosec', shell=True)
 subprocess.Popen('/bin/ls *', shell=True) # type: … # nosec # noqa: E501 ; pylint: disable=line-too-long
+subprocess.Popen('/bin/ls *', shell=True)  #nosec subprocess_popen_with_shell_equals_true (on the line)
+subprocess.Popen('#nosec', shell=True) # nosec B607, B602
+subprocess.Popen('#nosec', shell=True) # nosec B607 B602
+subprocess.Popen('/bin/ls *', shell=True)  # nosec subprocess_popen_with_shell_equals_true start_process_with_partial_path
+subprocess.Popen('/bin/ls *', shell=True) # type: … # noqa: E501 ; pylint: disable=line-too-long # nosec
+subprocess.Popen('#nosec', shell=True) # nosec B607, B101
+subprocess.Popen('#nosec', shell=True) # nosec B602, subprocess_popen_with_shell_equals_true

--- a/examples/nosec.py
+++ b/examples/nosec.py
@@ -4,11 +4,12 @@ subprocess.Popen('/bin/ls *', #nosec (at the start of function call)
 subprocess.Popen('/bin/ls *',
                  shell=True)  #nosec (on the specific kwarg line)
 subprocess.Popen('#nosec', shell=True)
-subprocess.Popen('/bin/ls *', shell=True) # type: … # nosec # noqa: E501 ; pylint: disable=line-too-long
+subprocess.Popen('/bin/ls *', shell=True) # type: ... # nosec # noqa: E501 ; pylint: disable=line-too-long
+subprocess.Popen('/bin/ls *', shell=True) # type: ... # nosec B607 # noqa: E501 ; pylint: disable=line-too-long
 subprocess.Popen('/bin/ls *', shell=True)  #nosec subprocess_popen_with_shell_equals_true (on the line)
 subprocess.Popen('#nosec', shell=True) # nosec B607, B602
 subprocess.Popen('#nosec', shell=True) # nosec B607 B602
 subprocess.Popen('/bin/ls *', shell=True)  # nosec subprocess_popen_with_shell_equals_true start_process_with_partial_path
-subprocess.Popen('/bin/ls *', shell=True) # type: … # noqa: E501 ; pylint: disable=line-too-long # nosec
+subprocess.Popen('/bin/ls *', shell=True) # type: ... # noqa: E501 ; pylint: disable=line-too-long # nosec
 subprocess.Popen('#nosec', shell=True) # nosec B607, B101
 subprocess.Popen('#nosec', shell=True) # nosec B602, subprocess_popen_with_shell_equals_true

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -747,8 +747,8 @@ class FunctionalTests(testtools.TestCase):
 
     def test_nosec(self):
         expect = {
-            "SEVERITY": {"UNDEFINED": 0, "LOW": 2, "MEDIUM": 0, "HIGH": 0},
-            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 2},
+            "SEVERITY": {"UNDEFINED": 0, "LOW": 4, "MEDIUM": 0, "HIGH": 0},
+            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 4},
         }
         self.check_example("nosec.py", expect)
 

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -747,8 +747,8 @@ class FunctionalTests(testtools.TestCase):
 
     def test_nosec(self):
         expect = {
-            "SEVERITY": {"UNDEFINED": 0, "LOW": 4, "MEDIUM": 0, "HIGH": 0},
-            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 4},
+            "SEVERITY": {"UNDEFINED": 0, "LOW": 5, "MEDIUM": 0, "HIGH": 0},
+            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 5},
         }
         self.check_example("nosec.py", expect)
 

--- a/tests/unit/formatters/test_text.py
+++ b/tests/unit/formatters/test_text.py
@@ -107,7 +107,9 @@ class TextFormatterTests(testtools.TestCase):
 
         get_issue_list.return_value = [issue_a, issue_b]
 
-        self.manager.metrics.data["_totals"] = {"loc": 1000, "nosec": 50}
+        self.manager.metrics.data["_totals"] = {"loc": 1000, "nosec": 50,
+                                                "nosec_by_test": 0,
+                                                "failed_nosec_by_test": 0}
         for category in ["SEVERITY", "CONFIDENCE"]:
             for level in ["UNDEFINED", "LOW", "MEDIUM", "HIGH"]:
                 self.manager.metrics.data["_totals"][f"{category}.{level}"] = 1
@@ -153,6 +155,10 @@ class TextFormatterTests(testtools.TestCase):
                 "High: 1",
                 "Total lines skipped ",
                 "(#nosec): 50",
+                "Total lines skipped ",
+                "(#nosec BXXX,BYYY,...): 0",
+                "Total other nosec test caught ",
+                "(#nosec BXXX,BYYY but BZZZ): 0",
                 "Total issues (by severity)",
                 "Total issues (by confidence)",
                 "Files skipped (1)",

--- a/tests/unit/formatters/test_text.py
+++ b/tests/unit/formatters/test_text.py
@@ -107,9 +107,12 @@ class TextFormatterTests(testtools.TestCase):
 
         get_issue_list.return_value = [issue_a, issue_b]
 
-        self.manager.metrics.data["_totals"] = {"loc": 1000, "nosec": 50,
-                                                "nosec_by_test": 0,
-                                                "failed_nosec_by_test": 0}
+        self.manager.metrics.data["_totals"] = {
+            "loc": 1000,
+            "nosec": 50,
+            "nosec_by_test": 0,
+            "failed_nosec_by_test": 0,
+        }
         for category in ["SEVERITY", "CONFIDENCE"]:
             for level in ["UNDEFINED", "LOW", "MEDIUM", "HIGH"]:
                 self.manager.metrics.data["_totals"][f"{category}.{level}"] = 1

--- a/tests/unit/formatters/test_text.py
+++ b/tests/unit/formatters/test_text.py
@@ -110,8 +110,7 @@ class TextFormatterTests(testtools.TestCase):
         self.manager.metrics.data["_totals"] = {
             "loc": 1000,
             "nosec": 50,
-            "nosec_by_test": 0,
-            "failed_nosec_by_test": 0,
+            "skipped_tests": 0,
         }
         for category in ["SEVERITY", "CONFIDENCE"]:
             for level in ["UNDEFINED", "LOW", "MEDIUM", "HIGH"]:
@@ -158,10 +157,8 @@ class TextFormatterTests(testtools.TestCase):
                 "High: 1",
                 "Total lines skipped ",
                 "(#nosec): 50",
-                "Total lines skipped ",
-                "(#nosec BXXX,BYYY,...): 0",
-                "Total other nosec test caught ",
-                "(#nosec BXXX,BYYY but BZZZ): 0",
+                "Total potential issues skipped due to specifically being ",
+                "disabled (e.g., #nosec BXXX): 0",
                 "Total issues (by severity)",
                 "Total issues (by confidence)",
                 "Files skipped (1)",


### PR DESCRIPTION
This PR allows for disabling specific tests by ID (e.g. B602, B607). It also supports using test name (e.g. subprocess_popen_with_shell_equals_true) as requested in #418 .

the nosec comment behaves nicely with others and can be present anywhere in a string of comments.

If nosec is used without specific tests, it acts as it did before by blanket ignoring all tests for that line.
If nosec is used with specific tests and a test not indicated in the comments is triggered, the line will be caught and reported.