### PR TITLE
Add skip configuration to assert_used

### DIFF
--- a/bandit/core/context.py
+++ b/bandit/core/context.py
@@ -314,3 +314,7 @@ class Context(object):
                 if module in imp:
                     return True
         return False
+
+    @property
+    def filename(self):
+        return self._context.get('filename')

--- a/bandit/plugins/asserts.py
+++ b/bandit/plugins/asserts.py
@@ -19,6 +19,16 @@ Please see
 https://docs.python.org/3/reference/simple_stmts.html#the-assert-statement for
 more info on ``assert``
 
+**Config Options:**
+
+You can configure files that skip this check. This is often useful when you
+use assert statements in test cases.
+
+.. code-block:: yaml
+
+    assert_used:
+      skips: ['*_test.py', 'test_*.py']
+
 :Example:
 
 .. code-block:: none

--- a/bandit/plugins/asserts.py
+++ b/bandit/plugins/asserts.py
@@ -39,14 +39,25 @@ more info on ``assert``
 .. versionadded:: 0.11.0
 
 """
+import fnmatch
 
 import bandit
 from bandit.core import test_properties as test
 
 
+def gen_config(name):
+    if name == 'assert_used':
+        return {'skips': []}
+
+
+@test.takes_config
 @test.test_id('B101')
 @test.checks('Assert')
-def assert_used(context):
+def assert_used(context, config):
+    for skip in config.get('skips', []):
+        if fnmatch.fnmatch(context.filename, skip):
+            return None
+
     return bandit.Issue(
         severity=bandit.LOW,
         confidence=bandit.HIGH,

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -601,6 +601,24 @@ class FunctionalTests(testtools.TestCase):
 
     def test_asserts(self):
         '''Test catching the use of assert.'''
+        test = next((x for x in self.b_mgr.b_ts.tests['Assert']
+                     if x.__name__ == 'assert_used'))
+
+        test._config = {'skips': []}
+        expect = {
+            'SEVERITY': {'UNDEFINED': 0, 'LOW': 1, 'MEDIUM': 0, 'HIGH': 0},
+            'CONFIDENCE': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 0, 'HIGH': 1}
+        }
+        self.check_example('assert.py', expect)
+
+        test._config = {'skips': ['*assert.py']}
+        expect = {
+            'SEVERITY': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 0, 'HIGH': 0},
+            'CONFIDENCE': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 0, 'HIGH': 0}
+        }
+        self.check_example('assert.py', expect)
+
+        test._config = {}
         expect = {
             'SEVERITY': {'UNDEFINED': 0, 'LOW': 1, 'MEDIUM': 0, 'HIGH': 0},
             'CONFIDENCE': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 0, 'HIGH': 1}

--- a/tests/unit/core/test_context.py
+++ b/tests/unit/core/test_context.py
@@ -254,3 +254,12 @@ class ContextTests(testtools.TestCase):
 
         new_context = context.Context()
         self.assertFalse(new_context.is_module_imported_like('spam'))
+
+    def test_filename(self):
+        ref_context = dict(filename='spam.py')
+        new_context = context.Context(context_object=ref_context)
+
+        self.assertEqual(new_context.filename, 'spam.py')
+
+        new_context = context.Context()
+        self.assertIsNone(new_context.filename)


### PR DESCRIPTION
Adding this configuration allows the user to skip the assert_used check
against some files. This is useful because asserts are very common
in test files when using pytest.

Specifying this configuration:

```
assert_used:
  skips: ['test.py$', '^test']
```

would skip all asserts against a test file.

Resolves #346

Thank you for the awesome project and your time!