### PR TITLE
Fix #495 - replace `fdata.readline` with `lines` iteration 

### DIFF
--- a/bandit/core/manager.py
+++ b/bandit/core/manager.py
@@ -270,9 +270,9 @@ class BanditManager(object):
                 try:
                     tmp = list(lines)
                     if six.PY2:
-                        tokens = tokenize.generate_tokens(lambda: tmp.pop(0))
+                        tokens = tokenize.generate_tokens(lambda: tmp.pop(0) if tmp else b'')
                     else:
-                        tokens = tokenize.tokenize(lambda: tmp.pop(0))
+                        tokens = tokenize.tokenize(lambda: tmp.pop(0) if tmp else b'')
                     nosec_lines = set(
                         lineno for toktype, tokval, (lineno, _), _, _ in tokens
                         if toktype == tokenize.COMMENT and

--- a/bandit/core/manager.py
+++ b/bandit/core/manager.py
@@ -268,11 +268,11 @@ class BanditManager(object):
                 nosec_lines = set()
             else:
                 try:
-                    fdata.seek(0)
+                    tmp = list(lines)
                     if six.PY2:
-                        tokens = tokenize.generate_tokens(fdata.readline)
+                        tokens = tokenize.generate_tokens(lambda: tmp.pop(0))
                     else:
-                        tokens = tokenize.tokenize(fdata.readline)
+                        tokens = tokenize.tokenize(lambda: tmp.pop(0))
                     nosec_lines = set(
                         lineno for toktype, tokval, (lineno, _), _, _ in tokens
                         if toktype == tokenize.COMMENT and
@@ -287,7 +287,7 @@ class BanditManager(object):
         except SyntaxError:
             self.skipped.append((fname,
                                  "syntax error while parsing AST from file"))
-            new_files_list.remove(fname)
+            new_files_list.remove("<stdin>" if fname == '-' else fname)
         except Exception as e:
             LOG.error("Exception occurred when executing tests against "
                       "%s. Run \"bandit --debug %s\" to see the full "

--- a/tests/functional/test_runtime.py
+++ b/tests/functional/test_runtime.py
@@ -14,12 +14,12 @@ class RuntimeTests(testtools.TestCase):
     def _test_runtime(self, cmdlist, infile=None):
         process = subprocess.Popen(
             cmdlist,
-            stdin=infile if infile else subprocess.PIPE,
+            stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             close_fds=True
         )
-        stdout, stderr = process.communicate()
+        stdout, stderr = process.communicate(input=infile)
         retcode = process.poll()
         return (retcode, stdout.decode('utf-8'))
 
@@ -35,7 +35,7 @@ class RuntimeTests(testtools.TestCase):
 
     def test_piped_input(self):
         with open('examples/imports.py', 'r') as infile:
-            (retcode, output) = self._test_runtime(['bandit', '-'], infile)
+            (retcode, output) = self._test_runtime(['bandit', '-'], infile.read())
             self.assertEqual(1, retcode)
             self.assertIn("Total lines of code: 4", output)
             self.assertIn("Low: 2", output)


### PR DESCRIPTION
A pipe input (e.g. `cat test.py | bandit -`) does not allow `fdata.seek(0)`. But because the input content is already in the `lines` list, we can use `lines` instead of `fdata` and eliminate the need for  seek.

I also update the `test_runtime` to fail if this issue is not fixed.

 