### PR TITLE
Update calls.py with additional rulesets

### DIFF
--- a/bandit/blacklists/calls.py
+++ b/bandit/blacklists/calls.py
@@ -568,5 +568,51 @@ def gen_blacklist():
         'Use of os.tempnam() and os.tmpnam() is vulnerable to symlink '
         'attacks. Consider using tmpfile() instead.'
         ))
+    
+    # updated rulesets starts here
+    
+    sets.append(utils.build_conf_dict(
+        'yaml_load', 'B326',
+        ['yaml.load'],
+        'Use of this deprecated deserialize method leads to remote code execution. See CVE-2017-18342.'
+        'Use yaml.safe_load instead.'
+        ))
 
+    sets.append(utils.build_conf_dict(
+        'response_splitting', 'B327',
+        ['urllib2.Request.add_header',
+        'urllib.URLopener.addheader',
+        'urllib.URLopener.addheaders'], 
+        'Python Urllib and Urllib2 are vulnerable to CRLF injection.'
+        'See https://bugs.python.org/issue36276'
+        ))
+    
+    sets.append(utils.build_conf_dict(
+        'Base64_encoding_used', 'B009',
+        ['base64.b64encode',
+        'base64.standard_b64encode',
+        'base64.urlsafe_b64encode',
+        'base64.b16encode',
+        'base64.b32encode',
+        'base64.encodestring',
+        'flask_scrypt.enbase64',
+        'base64.b64decode'],
+        'Weak encoding alogirthm. Encoding and storing sensitive information using this algorithm gives a false sense of security.',
+        'LOW'
+        ))
+    
+    sets.append(utils.build_conf_dict(
+        'Server_Side_Template_Injection', 'B017',
+        ['render_template_string', 'render_template'],
+        'User controlled Values injected into the template can lead to arbitrary code executions in the server. Check if input values are properly sanitized. See https://blog.nvisium.com/p263',
+        'MEDIUM'
+        ))
+    
+    sets.append(utils.build_conf_dict(
+        'file_upload', 'B024',
+        ['Flask.send_file'],
+        'Presence of a file upload funtionality. Ensure that the application whitelists the allowed file extensions and validated the MIME type.',
+        'MEDIUM'
+        ))
+    
     return {'Call': sets}

--- a/bandit/blacklists/calls.py
+++ b/bandit/blacklists/calls.py
@@ -580,29 +580,27 @@ def gen_blacklist():
 
     sets.append(utils.build_conf_dict(
         'response_splitting', 'B327',
-        ['urllib2.Request.add_header','urllib.URLopener.addheader','urllib.URLopener.addheaders'], 
+        ['urllib2.Request.add_header', 'urllib.URLopener.addheader', 'urllib.URLopener.addheaders'], 
         'Python Urllib and Urllib2 are vulnerable to CRLF injection.'
         'See https://bugs.python.org/issue36276'
         ))
     
     sets.append(utils.build_conf_dict(
         'Base64_encoding_used', 'B328',
-        ['base64.b64encode','base64.standard_b64encode','base64.urlsafe_b64encode','base64.b16encode','base64.b32encode','base64.encodestring','flask_scrypt.enbase64','base64.b64decode'],
-        'Weak encoding alogirthm. Encoding and storing sensitive information using this algorithm gives a false sense of security.','LOW'
+        ['base64.b64encode', 'base64.standard_b64encode', 'base64.urlsafe_b64encode', 'base64.b16encode', 'base64.b32encode', 'base64.encodestring', 'flask_scrypt.enbase64', 'base64.b64decode'],
+        'Weak encoding alogirthm. Encoding and storing sensitive information using this algorithm gives a false sense of security.'
         ))
     
     sets.append(utils.build_conf_dict(
         'Server_Side_Template_Injection', 'B329',
         ['render_template_string', 'render_template'],
-        'User controlled Values injected into the template can lead to arbitrary code executions in the server. Check if input values are properly sanitized. See https://blog.nvisium.com/p263',
-        'MEDIUM'
+        'User controlled Values injected into the template can lead to arbitrary code executions in the server. Check if input values are properly sanitized. See https://blog.nvisium.com/p263'
         ))
     
     sets.append(utils.build_conf_dict(
         'file_upload', 'B330',
         ['Flask.send_file'],
         'Presence of a file upload funtionality. Ensure that the application whitelists the allowed file extensions and validated the MIME type.',
-        'MEDIUM'
         ))
     
     return {'Call': sets}

--- a/bandit/blacklists/calls.py
+++ b/bandit/blacklists/calls.py
@@ -568,39 +568,66 @@ def gen_blacklist():
         'Use of os.tempnam() and os.tmpnam() is vulnerable to symlink '
         'attacks. Consider using tmpfile() instead.'
         ))
-    
+
     # updated rulesets starts here
-    
+
     sets.append(utils.build_conf_dict(
         'yaml_load', 'B326',
         ['yaml.load'],
-        'Use of this deprecated deserialize method leads to remote code execution. See CVE-2017-18342.'
+        """
+        Use of this deprecated deserialize method leads to
+        remote code execution. See CVE-2017-18342.
+        """
         'Use yaml.safe_load instead.'
         ))
 
     sets.append(utils.build_conf_dict(
         'response_splitting', 'B327',
-        ['urllib2.Request.add_header', 'urllib.URLopener.addheader', 'urllib.URLopener.addheaders'], 
+        [
+            'urllib2.Request.add_header',
+            'urllib.URLopener.addheader',
+            'urllib.URLopener.addheaders'
+        ],
         'Python Urllib and Urllib2 are vulnerable to CRLF injection.'
         'See https://bugs.python.org/issue36276'
         ))
-    
+
     sets.append(utils.build_conf_dict(
         'Base64_encoding_used', 'B328',
-        ['base64.b64encode', 'base64.standard_b64encode', 'base64.urlsafe_b64encode', 'base64.b16encode', 'base64.b32encode', 'base64.encodestring', 'flask_scrypt.enbase64', 'base64.b64decode'],
-        'Weak encoding alogirthm. Encoding and storing sensitive information using this algorithm gives a false sense of security.'
+        [
+            'base64.b64encode',
+            'base64.standard_b64encode',
+            'base64.urlsafe_b64encode',
+            'base64.b16encode',
+            'base64.b32encode',
+            'base64.encodestring',
+            'flask_scrypt.enbase64',
+            'base64.b64decode'
+        ],
+        """
+        Weak encoding alogirthm. Encoding and storing sensitive
+        information using this algorithm gives a false sense of security.
+        """
         ))
-    
+
     sets.append(utils.build_conf_dict(
         'Server_Side_Template_Injection', 'B329',
         ['render_template_string', 'render_template'],
-        'User controlled Values injected into the template can lead to arbitrary code executions in the server. Check if input values are properly sanitized. See https://blog.nvisium.com/p263'
+        """
+        User controlled Values injected into the template can lead to
+        arbitrary code executions in the server. Check if input values
+        are properly sanitized. See https://blog.nvisium.com/p263
+        """
         ))
-    
+
     sets.append(utils.build_conf_dict(
         'file_upload', 'B330',
         ['Flask.send_file'],
-        'Presence of a file upload funtionality. Ensure that the application whitelists the allowed file extensions and validated the MIME type.',
+        """
+        Presence of a file upload funtionality. Ensure that the
+        application whitelists the allowed file extensions and
+        validated the MIME type.'
+        """
         ))
-    
+
     return {'Call': sets}

--- a/bandit/blacklists/calls.py
+++ b/bandit/blacklists/calls.py
@@ -580,36 +580,26 @@ def gen_blacklist():
 
     sets.append(utils.build_conf_dict(
         'response_splitting', 'B327',
-        ['urllib2.Request.add_header',
-        'urllib.URLopener.addheader',
-        'urllib.URLopener.addheaders'], 
+        ['urllib2.Request.add_header','urllib.URLopener.addheader','urllib.URLopener.addheaders'], 
         'Python Urllib and Urllib2 are vulnerable to CRLF injection.'
         'See https://bugs.python.org/issue36276'
         ))
     
     sets.append(utils.build_conf_dict(
-        'Base64_encoding_used', 'B009',
-        ['base64.b64encode',
-        'base64.standard_b64encode',
-        'base64.urlsafe_b64encode',
-        'base64.b16encode',
-        'base64.b32encode',
-        'base64.encodestring',
-        'flask_scrypt.enbase64',
-        'base64.b64decode'],
-        'Weak encoding alogirthm. Encoding and storing sensitive information using this algorithm gives a false sense of security.',
-        'LOW'
+        'Base64_encoding_used', 'B328',
+        ['base64.b64encode','base64.standard_b64encode','base64.urlsafe_b64encode','base64.b16encode','base64.b32encode','base64.encodestring','flask_scrypt.enbase64','base64.b64decode'],
+        'Weak encoding alogirthm. Encoding and storing sensitive information using this algorithm gives a false sense of security.','LOW'
         ))
     
     sets.append(utils.build_conf_dict(
-        'Server_Side_Template_Injection', 'B017',
+        'Server_Side_Template_Injection', 'B329',
         ['render_template_string', 'render_template'],
         'User controlled Values injected into the template can lead to arbitrary code executions in the server. Check if input values are properly sanitized. See https://blog.nvisium.com/p263',
         'MEDIUM'
         ))
     
     sets.append(utils.build_conf_dict(
-        'file_upload', 'B024',
+        'file_upload', 'B330',
         ['Flask.send_file'],
         'Presence of a file upload funtionality. Ensure that the application whitelists the allowed file extensions and validated the MIME type.',
         'MEDIUM'


### PR DESCRIPTION
Added new rule sets to detect common vulnerabilities in default libraries in python.
Some common vulnerabilities observed are - 
1. Use of yaml_load - Insecure and deprecated. Leads to arbitrary server code execution
2. Vulnerable libraries that allow response splitting vulnerabilities (or) CRLF injection attacks.
3. Use of base64 encoding algorithm - I have observed sensitive information being encoded using this algorithm. Gives a false sense of security.
4. Server-Side Template Injection - Primarily seen in flask based applications. The use of default libraries (without validation) allow users to run commands in the server using templates.
5. Check file upload functionalities in python code - You can check if the application has validation on the file extension and MIME types. Can lead to RCE or malicious file uploads. 