### PR TITLE
Fix # noqa rendering in docs

### DIFF
--- a/bandit/plugins/app_debug.py
+++ b/bandit/plugins/app_debug.py
@@ -33,11 +33,11 @@ of the Patreon breach in 2015 [3]_.
 
  .. [1] http://flask.pocoo.org/docs/1.0/quickstart/#debug-mode
  .. [2] http://werkzeug.palletsprojects.com/en/0.15.x/debug/
- .. [3] http://labs.detectify.com/post/130332638391/how-patreon-got-hacked-publicly-exposed-werkzeug  # noqa
+ .. [3] http://labs.detectify.com/post/130332638391/how-patreon-got-hacked-publicly-exposed-werkzeug
 
 .. versionadded:: 0.15.0
 
-"""
+"""  # noqa: E501
 
 import bandit
 from bandit.core import test_properties as test

--- a/bandit/plugins/general_bad_file_permissions.py
+++ b/bandit/plugins/general_bad_file_permissions.py
@@ -39,13 +39,13 @@ set world writable. Warnings are given with HIGH confidence.
 
 .. seealso::
 
- - https://security.openstack.org/guidelines/dg_apply-restrictive-file-permissions.html  # noqa
+ - https://security.openstack.org/guidelines/dg_apply-restrictive-file-permissions.html
  - https://en.wikipedia.org/wiki/File_system_permissions
  - https://security.openstack.org
 
 .. versionadded:: 0.9.0
 
-"""
+"""  # noqa: E501
 
 import stat
 

--- a/bandit/plugins/general_hardcoded_tmp.py
+++ b/bandit/plugins/general_hardcoded_tmp.py
@@ -44,11 +44,11 @@ issue.
 
 .. seealso::
 
- - https://security.openstack.org/guidelines/dg_using-temporary-files-securely.html  # noqa
+ - https://security.openstack.org/guidelines/dg_using-temporary-files-securely.html
 
 .. versionadded:: 0.9.0
 
-"""
+"""  # noqa: E501
 
 import bandit
 from bandit.core import test_properties as test

--- a/bandit/plugins/injection_shell.py
+++ b/bandit/plugins/injection_shell.py
@@ -186,12 +186,12 @@ def subprocess_popen_with_shell_equals_true(context, config):
     .. seealso::
 
      - https://security.openstack.org
-     - https://docs.python.org/3/library/subprocess.html#frequently-used-arguments  # noqa
+     - https://docs.python.org/3/library/subprocess.html#frequently-used-arguments
      - https://security.openstack.org/guidelines/dg_use-subprocess-securely.html
      - https://security.openstack.org/guidelines/dg_avoid-shell-true.html
 
     .. versionadded:: 0.9.0
-    """
+    """  # noqa: E501
     if config and context.call_function_name_qual in config['subprocess']:
         if has_shell(context):
             if len(context.call_args) > 0:
@@ -277,12 +277,12 @@ def subprocess_without_shell_equals_true(context, config):
     .. seealso::
 
      - https://security.openstack.org
-     - https://docs.python.org/3/library/subprocess.html#frequently-used-arguments  # noqa
+     - https://docs.python.org/3/library/subprocess.html#frequently-used-arguments
      - https://security.openstack.org/guidelines/dg_avoid-shell-true.html
      - https://security.openstack.org/guidelines/dg_use-subprocess-securely.html
 
     .. versionadded:: 0.9.0
-    """
+    """  # noqa: E501
     if config and context.call_function_name_qual in config['subprocess']:
         if not has_shell(context):
             return bandit.Issue(
@@ -357,10 +357,10 @@ def any_other_function_with_shell_equals_true(context, config):
     .. seealso::
 
      - https://security.openstack.org/guidelines/dg_avoid-shell-true.html
-     - https://security.openstack.org/guidelines/dg_use-subprocess-securely.html  # noqa
+     - https://security.openstack.org/guidelines/dg_use-subprocess-securely.html
 
     .. versionadded:: 0.9.0
-    """
+    """  # noqa: E501
     if config and context.call_function_name_qual not in config['subprocess']:
         if has_shell(context):
             return bandit.Issue(
@@ -440,11 +440,11 @@ def start_process_with_a_shell(context, config):
 
      - https://security.openstack.org
      - https://docs.python.org/3/library/os.html#os.system
-     - https://docs.python.org/3/library/subprocess.html#frequently-used-arguments  # noqa
+     - https://docs.python.org/3/library/subprocess.html#frequently-used-arguments
      - https://security.openstack.org/guidelines/dg_use-subprocess-securely.html
 
     .. versionadded:: 0.10.0
-    """
+    """  # noqa: E501
     if config and context.call_function_name_qual in config['shell']:
         if len(context.call_args) > 0:
             sev = _evaluate_shell_call(context)
@@ -538,11 +538,11 @@ def start_process_with_no_shell(context, config):
 
      - https://security.openstack.org
      - https://docs.python.org/3/library/os.html#os.system
-     - https://docs.python.org/3/library/subprocess.html#frequently-used-arguments  # noqa
+     - https://docs.python.org/3/library/subprocess.html#frequently-used-arguments
      - https://security.openstack.org/guidelines/dg_use-subprocess-securely.html
 
     .. versionadded:: 0.10.0
-    """
+    """  # noqa: E501
 
     if config and context.call_function_name_qual in config['no_shell']:
         return bandit.Issue(

--- a/bandit/plugins/injection_sql.py
+++ b/bandit/plugins/injection_sql.py
@@ -45,11 +45,11 @@ If so, a MEDIUM issue is reported. For example:
 .. seealso::
 
  - https://www.owasp.org/index.php/SQL_Injection
- - https://security.openstack.org/guidelines/dg_parameterize-database-queries.html  # noqa
+ - https://security.openstack.org/guidelines/dg_parameterize-database-queries.html
 
 .. versionadded:: 0.9.0
 
-"""
+"""  # noqa: E501
 
 import ast
 import re


### PR DESCRIPTION
Move `# noqa` from inside docstrings to the end of the docstring. This avoids rendering the **# noqa** tag in the documentation as reported in #644 while preventing flagging the excessive line lengths in the linting.

Note: I also added the `E501` label to maintain the original intent of applying the `# noqa` tag to the long lines only.

Fixes #644.