### PR TITLE
Use GitHub Action badge for build

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,8 @@
 
 ======
 
-.. image:: https://travis-ci.org/PyCQA/bandit.svg?branch=master
-    :target: https://travis-ci.org/PyCQA/bandit/
+.. image:: https://github.com/PyCQA/bandit/workflows/Build%20and%20Test%20Bandit/badge.svg
+    :target: https://github.com/PyCQA/bandit/actions?query=workflow%3A%22Build+and+Test+Bandit%22
     :alt: Build Status
 
 .. image:: https://readthedocs.org/projects/bandit/badge/?version=latest


### PR DESCRIPTION
We no longer use Travis CI, so we shouldn't be using it's badge. This
change switches to the GitHub Action badge.