### PR TITLE
Remove universal support on the wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -131,6 +131,3 @@ source-dir = doc/source
 autodoc_tree_index_modules = True
 autodoc_tree_excludes =
   examples*
-
-[bdist_wheel]
-universal = 1


### PR DESCRIPTION
Now that Bandit is Py3 only, it should be considered a "Pure-Python
Wheel" instead of a "Universal". Further information can be found
here: https://realpython.com/python-wheels/#specifying-a-universal-wheel

Fixes #654

Signed-off-by: Eric Brown <browne@vmware.com>