### PR TITLE
Clearer message for subprocess module use

### DIFF
--- a/bandit/blacklists/imports.py
+++ b/bandit/blacklists/imports.py
@@ -254,8 +254,8 @@ def gen_blacklist():
 
     sets.append(utils.build_conf_dict(
         'import_subprocess', 'B404', ['subprocess'],
-        'Consider possible security implications associated with '
-        '{name} module.', 'LOW'
+        'Consider possible security implications associated with the '
+        'subprocess module.', 'LOW'
         ))
 
     # Most of this is based off of Christian Heimes' work on defusedxml:


### PR DESCRIPTION
This change modifies the warning using subprocess module. The
module is subprocess, and anything else is a submodule or function.

Fixes #666

Signed-off-by: Eric Brown <browne@vmware.com>