### PR TITLE
Specify language_version in .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,4 +3,5 @@
     description: 'Bandit is a tool for finding common security issues in Python code'
     entry: bandit
     language: python
+    language_version: python3
     types: [python]


### PR DESCRIPTION
Since b78c938c0bd03d201932570f5e054261e10c5750, the project no longer
supports Python 2.

pre-commit will use the system Python by default. On some systems, this
could be Python 2. To avoid Python 2 usage, specify pre-commit always
uses Python 3.

Without this configuration, some projects have been forced to manually
override this option.

pre-commit docs:
https://pre-commit.com/#overriding-language-version