### PR TITLE
Show column offset on all formatters

### DIFF
--- a/bandit/formatters/csv.py
+++ b/bandit/formatters/csv.py
@@ -59,6 +59,7 @@ def report(manager, fileobj, sev_level, conf_level, lines=-1):
                       'issue_confidence',
                       'issue_text',
                       'line_number',
+                      'col_offset',
                       'line_range',
                       'more_info']
 

--- a/bandit/formatters/screen.py
+++ b/bandit/formatters/screen.py
@@ -102,9 +102,10 @@ def _output_issue_str(issue, indent, show_lineno=True, show_code=True,
     bits.append("%s   Severity: %s   Confidence: %s" % (
         indent, issue.severity.capitalize(), issue.confidence.capitalize()))
 
-    bits.append("%s   Location: %s:%s" % (
+    bits.append("%s   Location: %s:%s:%s" % (
         indent, issue.fname,
-        issue.lineno if show_lineno else ""))
+        issue.lineno if show_lineno else "",
+        issue.col_offset if show_lineno else ""))
 
     bits.append("%s   More Info: %s%s" % (
         indent, docs_utils.get_url(issue.test_id), COLOR['DEFAULT']))

--- a/bandit/formatters/text.py
+++ b/bandit/formatters/text.py
@@ -76,8 +76,9 @@ def _output_issue_str(issue, indent, show_lineno=True, show_code=True,
     bits.append("%s   Severity: %s   Confidence: %s" % (
         indent, issue.severity.capitalize(), issue.confidence.capitalize()))
 
-    bits.append("%s   Location: %s:%s" % (
-        indent, issue.fname, issue.lineno if show_lineno else ""))
+    bits.append("%s   Location: %s:%s:%s" % (
+        indent, issue.fname, issue.lineno if show_lineno else "",
+        issue.col_offset if show_lineno else ""))
 
     bits.append("%s   More Info: %s" % (
         indent, docs_utils.get_url(issue.test_id)))

--- a/tests/unit/formatters/test_screen.py
+++ b/tests/unit/formatters/test_screen.py
@@ -35,8 +35,9 @@ class ScreenFormatterTests(testtools.TestCase):
                           "{}   Severity: {}   Confidence: {}".
                           format(_indent_val, _issue.severity.capitalize(),
                                  _issue.confidence.capitalize()),
-                          "{}   Location: {}:{}".
-                          format(_indent_val, _issue.fname, _issue.lineno),
+                          "{}   Location: {}:{}:{}".
+                          format(_indent_val, _issue.fname, _issue.lineno,
+                                 _issue.col_offset),
                           "{}   More Info: {}{}".format(
                               _indent_val, docs_utils.get_url(_issue.test_id),
                               screen.COLOR['DEFAULT'])]
@@ -56,6 +57,7 @@ class ScreenFormatterTests(testtools.TestCase):
         self.assertEqual(expected_return, issue_text)
 
         issue.lineno = ''
+        issue.col_offset = ''
         issue_text = screen._output_issue_str(issue, indent_val,
                                               show_lineno=False)
         expected_return = _template(issue, indent_val, 'DDDDDDD',

--- a/tests/unit/formatters/test_text.py
+++ b/tests/unit/formatters/test_text.py
@@ -35,8 +35,9 @@ class TextFormatterTests(testtools.TestCase):
                           "{}   Severity: {}   Confidence: {}".
                           format(_indent_val, _issue.severity.capitalize(),
                                  _issue.confidence.capitalize()),
-                          "{}   Location: {}:{}".
-                          format(_indent_val, _issue.fname, _issue.lineno),
+                          "{}   Location: {}:{}:{}".
+                          format(_indent_val, _issue.fname, _issue.lineno,
+                                 _issue.col_offset),
                           "{}   More Info: {}".format(
                               _indent_val, docs_utils.get_url(_issue.test_id))]
             if _code:
@@ -53,6 +54,7 @@ class TextFormatterTests(testtools.TestCase):
         self.assertEqual(expected_return, issue_text)
 
         issue.lineno = ''
+        issue.col_offset = ''
         issue_text = b_text._output_issue_str(issue, indent_val,
                                               show_lineno=False)
         expected_return = _template(issue, indent_val, 'DDDDDDD')


### PR DESCRIPTION
Recently, #618 introduced column offsets to the custom formatter.
But other formatters should also show the column offset.

Signed-off-by: Eric Brown <browne@vmware.com>