### PR TITLE
Add default labels to issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,6 +1,9 @@
 ---
-name: 🐛 Bug report
+name: "\U0001F41B Bug report"
 about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,6 +1,9 @@
 ---
-name: 🚀 Feature request
+name: "\U0001F680 Feature request"
 about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
 
 ---
 


### PR DESCRIPTION
GitHub finally supports the ability to automatically default to a label given in the template.  This will save on manually assigning labels from now on.