### PR TITLE
Include the line number when using HTML output format

### DIFF
--- a/bandit/formatters/html.py
+++ b/bandit/formatters/html.py
@@ -263,6 +263,7 @@ pre {
     <b>Severity: </b>{severity}<br>
     <b>Confidence: </b>{confidence}<br>
     <b>File: </b><a href="{path}" target="_blank">{path}</a> <br>
+    <b>Line number: </b>{line_number}<br>
     <b>More info: </b><a href="{url}" target="_blank">{url}</a><br>
 {code}
 {candidates}
@@ -358,7 +359,8 @@ pre {
                                           confidence=issue.confidence,
                                           path=issue.fname, code=code,
                                           candidates=candidates,
-                                          url=url)
+                                          url=url,
+                                          line_number=issue.lineno)
 
     # build the metrics string to insert in the report
     metrics_summary = metrics_block.format(

--- a/tests/unit/formatters/test_html.py
+++ b/tests/unit/formatters/test_html.py
@@ -120,6 +120,7 @@ class HtmlFormatterTests(testtools.TestCase):
             self.assertIn('BBBBBBB', issue1.text)
             self.assertIn('CCCCCCC', issue1.text)
             self.assertIn('abc.py', issue1.text)
+            self.assertIn('Line number: 1', issue1.text)
 
     @mock.patch('bandit.core.issue.Issue.get_code')
     @mock.patch('bandit.core.manager.BanditManager.get_issue_list')


### PR DESCRIPTION
This commit is to include the line number of a given occurrence when using HTML output format.

Resolves: #672
