### PR TITLE
Add license to package installation metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ description-file =
 author = PyCQA
 author-email = code-quality@python.org
 home-page = https://bandit.readthedocs.io/en/latest/
+license = Apache-2.0 license
 classifier =
     Development Status :: 5 - Production/Stable
     Environment :: Console


### PR DESCRIPTION
This PR adds the license name to the package installation metadata so it can be checked automatically with [`importlib.metadata`](https://docs.python.org/3/library/importlib.metadata.html). We automatically check the license of all our dependencies this way, and bandit currently fails since it returns "UNKNOWN".