### PR TITLE
document that random.choices() isn't secure either

### DIFF
--- a/bandit/blacklists/calls.py
+++ b/bandit/blacklists/calls.py
@@ -191,6 +191,7 @@ purposes.
 |      |                     | - random.randrange                 |           |
 |      |                     | - random.randint                   |           |
 |      |                     | - random.choice                    |           |
+|      |                     | - random.choices                   |           |
 |      |                     | - random.uniform                   |           |
 |      |                     | - random.triangular                |           |
 +------+---------------------+------------------------------------+-----------+
@@ -447,6 +448,7 @@ def gen_blacklist():
          'random.randrange',
          'random.randint',
          'random.choice',
+         'random.choices',
          'random.uniform',
          'random.triangular'],
         'Standard pseudo-random generators are not suitable for '

--- a/examples/random_module.py
+++ b/examples/random_module.py
@@ -6,6 +6,7 @@ bad = random.random()
 bad = random.randrange()
 bad = random.randint()
 bad = random.choice()
+bad = random.choices()
 bad = random.uniform()
 bad = random.triangular()
 

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -355,8 +355,8 @@ class FunctionalTests(testtools.TestCase):
     def test_random_module(self):
         '''Test for the `random` module.'''
         expect = {
-            'SEVERITY': {'UNDEFINED': 0, 'LOW': 6, 'MEDIUM': 0, 'HIGH': 0},
-            'CONFIDENCE': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 0, 'HIGH': 6}
+            'SEVERITY': {'UNDEFINED': 0, 'LOW': 7, 'MEDIUM': 0, 'HIGH': 0},
+            'CONFIDENCE': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 0, 'HIGH': 7}
         }
         self.check_example('random_module.py', expect)
 


### PR DESCRIPTION
Because [`random.choices()`](https://docs.python.org/3/library/random.html#random.choices) wasn't explicitly listed in the "don't use this" list, I initially thought it was safer version of `random.choice()`.

I realized my mistake and used `secret.choice()` eventually, but this PR is to add `random.choices()` to the unsafe list.