### PR TITLE
Always use a Loader in yaml.load

### DIFF
--- a/tests/unit/formatters/test_yaml.py
+++ b/tests/unit/formatters/test_yaml.py
@@ -70,7 +70,7 @@ class YamlFormatterTests(testtools.TestCase):
                           self.issue.confidence)
 
         with open(self.tmp_fname) as f:
-            data = yaml.load(f.read())
+            data = yaml.load(f.read(), Loader=yaml.SafeLoader)
             self.assertIsNotNone(data['generated_at'])
             self.assertEqual(self.tmp_fname, data['results'][0]['filename'])
             self.assertEqual(self.issue.severity,


### PR DESCRIPTION
A recent change within pyyaml 6.0 has enforce use of a Loader argument
to yaml.load [1].

To comply, Bandit will use yaml.load with a Loader always. The plugin
to check for unsafe loaders of yaml module still applies.

[1] https://github.com/yaml/pyyaml/pull/561

Closes #744

Signed-off-by: Eric Brown <browne@vmware.com>