### PR TITLE
Drop end-of-life Python 3.5

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,8 +64,7 @@ You can test any changes with tox:
 ```shell script
 pip install tox
 tox -e pep8
-tox -e py27
-tox -e py35
+tox -e py37
 tox -e docs
 tox -e cover
 ```

--- a/README.rst
+++ b/README.rst
@@ -298,9 +298,9 @@ using RST::
 Under Which Version of Python Should I Install Bandit?
 ------------------------------------------------------
 The answer to this question depends on the project(s) you will be running
-Bandit against. If your project is only compatible with Python 3.5, you
-should install Bandit to run under Python 3.5. If your project is only
-compatible with Python 3.8, then use 3.8 respectively. If your project supports
+Bandit against. If your project is only compatible with Python 3.8, you
+should install Bandit to run under Python 3.8. If your project is only
+compatible with Python 3.9, then use 3.9 respectively. If your project supports
 both, you *could* run Bandit with both versions but you don't have to.
 
 Bandit uses the `ast` module from Python's standard library in order to

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifier =
     Operating System :: MacOS :: MacOS X
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.0
-envlist = py35,pep8
+envlist = py36,pep8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Python 3.5 hit the end-of-life on Sept 13, 2020. As a result,
Bandit should also drop support for it.

Signed-off-by: Eric Brown <browne@vmware.com>