### PR TITLE
Improve CI tests matrix

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -43,17 +43,17 @@ jobs:
     - name: Run tox
       run: tox -e pep8
 
-  py35:
+  tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5]
+        python-version: [["3.5", "35"], ["3.6", "36"], ["3.7", "37"], ["3.8", "38"], ["3.9", "39"]]
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python-version[0] }}
       uses: actions/setup-python@v1
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.python-version[0] }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -61,84 +61,4 @@ jobs:
         pip install -r test-requirements.txt
         pip install tox
     - name: Run tox
-      run: tox -e py35
-
-  py36:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.6]
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r test-requirements.txt
-        pip install tox
-    - name: Run tox
-      run: tox -e py36
-
-  py37:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.7]
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r test-requirements.txt
-        pip install tox
-    - name: Run tox
-      run: tox -e py37
-
-  py38:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.8]
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r test-requirements.txt
-        pip install tox
-    - name: Run tox
-      run: tox -e py38
-
-  py39:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.9]
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r test-requirements.txt
-        pip install tox
-    - name: Run tox
-      run: tox -e py39
+      run: tox -e py${{ matrix.python-version[1] }}


### PR DESCRIPTION
Improve tests CI job by defining matrix combination for Python version and associated tox environment.
This reduces duplication and eases future updates.

Here's what it looks like in the fork: https://github.com/mkniewallner/bandit/actions/runs/1460179210