### PR TITLE
django_rawsql_used: support keyword arguments used in `RawSQL`

### DIFF
--- a/bandit/plugins/django_sql_injection.py
+++ b/bandit/plugins/django_sql_injection.py
@@ -129,7 +129,12 @@ def django_rawsql_used(context):
     description = "Use of RawSQL potential SQL attack vector."
     if context.is_module_imported_like("django.db.models"):
         if context.call_function_name == "RawSQL":
-            sql = context.node.args[0]
+            if context.node.args:
+                sql = context.node.args[0]
+            else:
+                kwargs = keywords2dict(context.node.keywords)
+                sql = kwargs["sql"]
+
             if not isinstance(sql, ast.Str):
                 return bandit.Issue(
                     severity=bandit.MEDIUM,

--- a/examples/django_sql_injection_raw.py
+++ b/examples/django_sql_injection_raw.py
@@ -9,3 +9,5 @@ User.objects.annotate(val=RawSQL(raw, []))
 raw = '"username") AS "val" FROM "auth_user"' \
       ' WHERE "username"="admin" OR 1=%s --'
 User.objects.annotate(val=RawSQL(raw, [0]))
+User.objects.annotate(val=RawSQL(sql='{}secure'.format('no'), params=[]))
+User.objects.annotate(val=RawSQL(params=[], sql='{}secure'.format('no')))

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -527,8 +527,8 @@ class FunctionalTests(testtools.TestCase):
         """Test insecure raw functions on Django."""
 
         expect = {
-            "SEVERITY": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 4, "HIGH": 0},
-            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 4, "HIGH": 0},
+            "SEVERITY": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 6, "HIGH": 0},
+            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 6, "HIGH": 0},
         }
         self.check_example("django_sql_injection_raw.py", expect)
 


### PR DESCRIPTION
Fix rule B611: django_rawsql_used breaking when a user passes in keyword arguments to Django's `RawSQL`.

Closes #764