### PR TITLE
Drop end-of-life Python 3.6

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.7]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.7]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -42,26 +42,6 @@ jobs:
         pip install tox
     - name: Run tox
       run: tox -e pep8
-
-  py36:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.6]
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r test-requirements.txt
-        pip install tox
-    - name: Run tox
-      run: tox -e py36
 
   py37:
     runs-on: ubuntu-latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,10 +18,10 @@ classifier =
     Operating System :: MacOS :: MacOS X
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Security
 project_urls =
     Release notes = https://github.com/PyCQA/bandit/releases

--- a/setup.py
+++ b/setup.py
@@ -5,5 +5,5 @@ import setuptools
 
 
 setuptools.setup(
-    python_requires=">=3.5", setup_requires=["pbr>=2.0.0"], pbr=True
+    python_requires=">=3.7", setup_requires=["pbr>=2.0.0"], pbr=True
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.0
-envlist = py36,pep8
+envlist = py37,pep8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Python 3.6 hit the end-of-life on Dec 23, 2021. As a result,
Bandit should also drop support for it.

Signed-off-by: Eric Brown <browne@vmware.com>