### PR TITLE
with "pip install bandit", toml is missing if we want use a configfil…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ GitPython>=1.0.1 # BSD License (3 clause)
 PyYAML>=5.3.1 # MIT
 stevedore>=1.20.0 # Apache-2.0
 colorama>=0.3.9;platform_system=="Windows" # BSD License (3 clause)
+toml>=0.10.2 # MIT


### PR DESCRIPTION
Hello,

We use bandit in a stage pipeline git and we have an issue when we use a configfile **pyproject.toml** :

```
$ pip install bandit
$ bandit --verbose --recursive . --configfile pyproject.toml
Traceback (most recent call last):
  File "C:\Program Files\Python39\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Program Files\Python39\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Program Files\Python39\Scripts\bandit.exe\__main__.py", line 7, in <module>
  File "C:\Program Files\Python39\lib\site-packages\bandit\cli\main.py", line 355, in main
    b_conf = b_config.BanditConfig(config_file=args.config_file)
  File "C:\Program Files\Python39\lib\site-packages\bandit\core\config.py", line 40, in __init__
    import toml
ModuleNotFoundError: No module named 'toml'
```

```
$ poetry show bandit
name         : bandit
version      : 1.7.1
description  : Security oriented static analyser for python code.

dependencies
 - colorama >=0.3.9
 - GitPython >=1.0.1
 - PyYAML >=5.3.1
 - stevedore >=1.20.0
```

It seems the dependency **toml** is missing.
Could you accept to add it in **requirements.txt** ?

Thanks for your feedbacks.

See you
Nicolas Monfort
