### PR TITLE
Delete release-drafter.yml

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,7 +1,0 @@
-template: |
-  $CHANGES
-
-  TODO:
-  - [ ] Replace 'master' with next tag once created
-
-  [See full changelog](https://github.com/PyCQA/bandit/compare/$PREVIOUS_TAG...master)


### PR DESCRIPTION
GitHub now has an easy-to-use button to automatically add release notes. 
Therefore it's not necessary to use this yaml for an app we experimented with a while back.