### PR TITLE
Update issue template with latest versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -44,7 +44,9 @@ body:
       label: Bandit version
       description: Run "bandit --version" if unsure of version number
       options:
-        - 1.7.0 (Default)
+        - 1.7.2 (Default)
+        - 1.7.1
+        - 1.7.0
         - 1.6.3
         - 1.6.2
         - 1.6.1
@@ -63,7 +65,8 @@ body:
       label: Python version
       description: Run "bandit --version" if unsure of version number
       options:
-        - 3.9 (Default)
+        - 3.10 (Default)
+        - 3.9
         - 3.8
         - 3.7
         - 3.6


### PR DESCRIPTION
When opening an issue, the template only allows selecting versions
1.7.0 as the max. The python version is also limited to 3.9.

This change adds the recent Bandit versions of 1.7.1 and 1.7.2, and Python
version of 3.10