### PR TITLE
Use released version of gh-action-pypi-publish

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -23,7 +23,7 @@ jobs:
         python setup.py sdist bdist_wheel
 
     - name: Publish distribution to Test PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        password: ${{ secrets.test_pypi_password }}
+        password: ${{ secrets.TEST_PYPI_PASSWORD }}
         repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Avoid using master version of gh-action-pypi-publish. Some orgs such as PyCQA don't permit using
a non-released version of an Action. It's also not recommended by GitHub to use unreleased versions
of actions.

Fixes Issue #782