### PR TITLE
Update publish-to-pypi.yml

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -24,6 +24,6 @@ jobs:
 
     - name: Publish distribution to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        password: ${{ secrets.pypi_password }}
+        password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
A follow on to #784. This change also updates the action to publish to
PyPI (official) to use a released version of gh-action-pypi-publish instead of master.
This change also makes the secret variable stand out a little more with all caps.