### PR TITLE
Add functional test of snmp_security_check

### DIFF
--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -824,3 +824,11 @@ class FunctionalTests(testtools.TestCase):
             "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 0},
         }
         self.check_example("pycryptodome.py", expect)
+
+    def test_snmp_security_check(self):
+        """Test insecure and weak crypto usage of SNMP."""
+        expect = {
+            "SEVERITY": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 3, "HIGH": 0},
+            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 3},
+        }
+        self.check_example("snmp.py", expect)


### PR DESCRIPTION
This change adds a new functional test of the new snmp plugin
snmp_security_check.

Fixes: #790

Signed-off-by: Eric Brown <browne@vmware.com>