### PR TITLE
Fix up warnings in output of tox

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 [metadata]
 name = bandit
 summary = Security oriented static analyser for python code.
-description-file =
+description_file =
     README.rst
 author = PyCQA
-author-email = code-quality@python.org
-home-page = https://bandit.readthedocs.io/en/latest/
+author_email = code-quality@python.org
+home_page = https://bandit.readthedocs.io/en/latest/
 license = Apache-2.0 license
 classifier =
     Development Status :: 5 - Production/Stable


### PR DESCRIPTION
This change fixes the use of certain keywords in the setup.cfg
file. Substitutes '-' for '_'

Fixes: #792

Signed-off-by: Eric Brown <browne@vmware.com>