### PR TITLE
Avoid printing metrics as float point numbers

### DIFF
--- a/bandit/core/metrics.py
+++ b/bandit/core/metrics.py
@@ -85,7 +85,8 @@ class Metrics:
                     if label not in issue_counts:
                         issue_counts[label] = 0
                         count = (
-                            score[criteria][i] / constants.RANKING_VALUES[rank]
+                            score[criteria][i]
+                            // constants.RANKING_VALUES[rank]
                         )
                         issue_counts[label] += count
         return issue_counts


### PR DESCRIPTION
The metrics in the output was displaying counts as floats instead
of integers. For example, 15.0 instead of 15. This is due to a
divide call using '/' instead of '//' which rounds down the answer.

We shouldn't have fractional number results anyway since the counts
are always divisible by the rank values.

Signed-off-by: Eric Brown <browne@vmware.com>