### PR TITLE
 Add new plugin to check use of pyghmi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ this Bandit processes each file, builds an AST from it, and runs appropriate
 plugins against the AST nodes. Once Bandit has finished scanning all the files
 it generates a report.
 
-Bandit was originally developed within the OpenStack Security Project and 
+Bandit was originally developed within the OpenStack Security Project and
 later rehomed to PyCQA.
 
 Installation
@@ -224,6 +224,7 @@ Usage::
       B412  import_httpoxy
       B413  import_pycrypto
       B414  import_pycryptodome
+      B415  pyghmi
       B501  request_with_no_cert_validation
       B502  ssl_with_bad_version
       B503  ssl_with_bad_defaults

--- a/bandit/plugins/import_pyghmi.py
+++ b/bandit/plugins/import_pyghmi.py
@@ -17,6 +17,8 @@ r"""
 B415 Test for the usage of pyghmi library
 =========================================
 
+Warn the usage of pyghmi as IPMI is known to be a non-secure protocol.
+
 :Example:
 
 .. code-block:: none
@@ -28,7 +30,7 @@ B415 Test for the usage of pyghmi library
            3
            4	cmd = command.Command(bmc="bmc",
            5	                      userid="userid",
-           6	                      password="ZjE4ZjI0NTE4YmI2NGJj d")
+           6	                      password="ZjE4ZjI0NTE4YmI2NGJjd")
 
 .. seealso::
 

--- a/bandit/plugins/import_pyghmi.py
+++ b/bandit/plugins/import_pyghmi.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2018 Accenture
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+r"""
+=========================================
+B415 Test for the usage of pyghmi library
+=========================================
+
+:Example:
+
+.. code-block:: none
+
+        >> Issue: [B415:pyghmi] Usage of pyghmi library detected.
+           IPMI is known to be a non-secure protocol.
+           Severity: Medium   Confidence: Medium
+           Location: examples/pyghmi.py:4
+           3
+           4	cmd = command.Command(bmc="bmc",
+           5	                      userid="userid",
+           6	                      password="ZjE4ZjI0NTE4YmI2NGJj d")
+
+.. seealso::
+
+    - https://www.us-cert.gov/ncas/alerts/TA13-207A
+
+.. versionadded:: 1.5.0
+
+"""
+
+import bandit
+from bandit.core import test_properties as test
+
+
+@test.checks('Call')
+@test.test_id('B415')
+def pyghmi(context):
+    issue_text = ('Usage of pyghmi library detected. '
+                  'IPMI is known to be a non-secure protocol.')
+    for module in ['pyghmi']:
+        if context.is_module_imported_like(module):
+            return bandit.Issue(
+                severity=bandit.MEDIUM,
+                confidence=bandit.MEDIUM,
+                text=issue_text)

--- a/examples/pyghmi.py
+++ b/examples/pyghmi.py
@@ -1,0 +1,6 @@
+import pyghmi
+from pyghmi.ipmi import command
+
+cmd = command.Command(bmc="bmc",
+                      userid="userid",
+                      password="ZjE4ZjI0NTE4YmI2NGJjZDliOGY3ZmJiY2UyN2IzODQK")

--- a/examples/pyghmi.py
+++ b/examples/pyghmi.py
@@ -1,4 +1,3 @@
-import pyghmi
 from pyghmi.ipmi import command
 
 cmd = command.Command(bmc="bmc",

--- a/setup.cfg
+++ b/setup.cfg
@@ -118,6 +118,9 @@ bandit.plugins =
     # bandit/plugins/yaml_load.py
     yaml_load = bandit.plugins.yaml_load:yaml_load
 
+    # bandit/plugins/import_pyghmi.py
+    pyghmi = bandit.plugins.import_pyghmi:pyghmi
+
 [build_sphinx]
 all_files = 1
 build-dir = doc/build

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -771,3 +771,11 @@ class FunctionalTests(testtools.TestCase):
             'CONFIDENCE': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 0, 'HIGH': 2}
         }
         self.check_example('pycryptodome.py', expect)
+
+    def test_pyghmi(self):
+        '''Test calling pyghmi methods'''
+        expect = {
+            'SEVERITY': {'UNDEFINED': 0, 'LOW': 1, 'MEDIUM': 1, 'HIGH': 0},
+            'CONFIDENCE': {'UNDEFINED': 0, 'LOW': 0, 'MEDIUM': 2, 'HIGH': 0}
+        }
+        self.check_example('pyghmi.py', expect)


### PR DESCRIPTION
This patch set adds a new bandit plugin to check the use of pyghmi.

Closes #356

Signed-off-by: Tin Lam <tin@irrational.io>