### PR TITLE
Fix references to the default branch name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Here are guidelines and rules that can be helpful if you plan to want to get inv
     * [Extending Bandit](#extending-bandit)
 
 ## Code of Conduct
-Everyone who participates in this project is governed by the PyCQA [Code of Conduct](https://github.com/PyCQA/bandit/blob/master/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct).
+Everyone who participates in this project is governed by the PyCQA [Code of Conduct](https://github.com/PyCQA/bandit/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct).
 
 ## Reporting Bugs
 If you encounter a bug, please let us know about it. See the guide here [GitHub issues](https://guides.github.com/features/issues/).

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://github.com/PyCQA/bandit/blob/master/logo/logotype-sm.png
+.. image:: https://github.com/PyCQA/bandit/blob/main/logo/logotype-sm.png
     :alt: Bandit
 
 ======
@@ -24,7 +24,7 @@
     :alt: Format
 
 .. image:: https://img.shields.io/badge/license-Apache%202-blue.svg
-    :target: https://github.com/PyCQA/bandit/blob/master/LICENSE
+    :target: https://github.com/PyCQA/bandit/blob/main/LICENSE
     :alt: License
 
 A security linter from PyCQA
@@ -33,7 +33,7 @@ A security linter from PyCQA
 * Documentation: https://bandit.readthedocs.io/en/latest/
 * Source: https://github.com/PyCQA/bandit
 * Bugs: https://github.com/PyCQA/bandit/issues
-* Contributing: https://github.com/PyCQA/bandit/blob/master/CONTRIBUTING.md
+* Contributing: https://github.com/PyCQA/bandit/blob/main/CONTRIBUTING.md
 
 Overview
 --------
@@ -64,7 +64,7 @@ Contributing
 ------------
 
 Follow our Contributing file:
-https://github.com/PyCQA/bandit/blob/master/CONTRIBUTING.md
+https://github.com/PyCQA/bandit/blob/main/CONTRIBUTING.md
 
 Reporting Bugs
 --------------

--- a/bandit/core/manager.py
+++ b/bandit/core/manager.py
@@ -450,7 +450,7 @@ def _find_candidate_matches(unmatched_issues, results_list):
     be able to pick out the new one.
 
     :param unmatched_issues: List of issues that weren't present before
-    :param results_list: Master list of current Bandit findings
+    :param results_list: main list of current Bandit findings
     :return: A dictionary with a list of candidates for each issue
     """
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
 # The order of packages is significant, because pip processes them in the order
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
-sphinx!=1.6.6,!=1.6.7,>=1.6.2 # BSD
+sphinx>=4.0.0 # BSD
 sphinx-rtd-theme>=0.3.0

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -21,8 +21,8 @@ extensions = [
 # The suffix of source filenames.
 source_suffix = ".rst"
 
-# The master toctree document.
-master_doc = "index"
+# The root toctree document.
+root_doc = "index"
 
 # General information about the project.
 project = "Bandit"


### PR DESCRIPTION
The primary branch name has been renamed from master to main.
As a result of this, some references in the docs must also be
renamed so links are preserved.

Signed-off-by: Eric Brown <browne@vmware.com>