### PR TITLE
Respect color environment variables if set

### DIFF
--- a/bandit/cli/main.py
+++ b/bandit/cli/main.py
@@ -265,7 +265,15 @@ def main():
         ' not be listed in "low".',
         choices=["all", "low", "medium", "high"],
     )
-    output_format = "screen" if sys.stdout.isatty() else "txt"
+    output_format = (
+        "screen"
+        if (
+            sys.stdout.isatty()
+            and os.getenv("NO_COLOR") is None
+            and os.getenv("TERM") != "dumb"
+        )
+        else "txt"
+    )
     parser.add_argument(
         "-f",
         "--format",

--- a/bandit/core/manager.py
+++ b/bandit/core/manager.py
@@ -163,7 +163,15 @@ class BanditManager:
         try:
             formatters_mgr = extension_loader.MANAGER.formatters_mgr
             if output_format not in formatters_mgr:
-                output_format = "screen" if sys.stdout.isatty() else "txt"
+                output_format = (
+                    "screen"
+                    if (
+                        sys.stdout.isatty()
+                        and os.getenv("NO_COLOR") is None
+                        and os.getenv("TERM") != "dumb"
+                    )
+                    else "txt"
+                )
 
             formatter = formatters_mgr[output_format]
             report_func = formatter.plugin


### PR DESCRIPTION
According to command line standards [1], a command line should
do its best to honor certain environment variables requesting
whether color should be part of the standard output. Two such
vars include NO_COLOR (if set) and TERM (if set to dumb), when
set tell the CLI to disable color.

[1] https://clig.dev/#output

Partially-fixes #678

Signed-off-by: Eric Brown <browne@vmware.com>