### PR TITLE
Show usage with no arguments

### DIFF
--- a/bandit/cli/main.py
+++ b/bandit/cli/main.py
@@ -586,8 +586,9 @@ def main():
         )
 
     if not args.targets:
-        LOG.error("No targets found in CLI or ini files, exiting.")
+        parser.print_usage()
         sys.exit(2)
+
     # if the log format string was set in the options, reinitialize
     if b_conf.get_option("log_format"):
         log_format = b_conf.get_option("log_format")

--- a/tests/functional/test_runtime.py
+++ b/tests/functional/test_runtime.py
@@ -32,7 +32,7 @@ class RuntimeTests(testtools.TestCase):
             ]
         )
         self.assertEqual(2, retcode)
-        self.assertIn("No targets found in CLI or ini files", output)
+        self.assertIn("usage: bandit [-h]", output)
 
     def test_piped_input(self):
         with open("examples/imports.py") as infile:


### PR DESCRIPTION
The current behavior is to display an error when no arguments are
given that no files were found. This is a non-standard way for
a command line.

Rather than an error message, no arguments should display the
usage of the command itself.

Partially fixes #678

Signed-off-by: Eric Brown <browne@vmware.com>