### PR TITLE
Fix root doc for readthedocs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -22,7 +22,7 @@ extensions = [
 source_suffix = ".rst"
 
 # The root toctree document.
-root_doc = "index"
+master_doc = "index"
 
 # General information about the project.
 project = "Bandit"


### PR DESCRIPTION
The readthedocs is using Sphinx 1.8.6 which still uses the
legacy term master_doc for the root toctree.

Signed-off-by: Eric Brown <browne@vmware.com>