### PR TITLE
Use versioned links to docs

### DIFF
--- a/bandit/core/docs_utils.py
+++ b/bandit/core/docs_utils.py
@@ -2,11 +2,13 @@
 # Copyright 2016 Hewlett-Packard Development Company, L.P.
 #
 # SPDX-License-Identifier: Apache-2.0
-# where our docs are hosted
-BASE_URL = "https://bandit.readthedocs.io/en/latest/"
+import bandit
 
 
 def get_url(bid):
+    # where our docs are hosted
+    base_url = f"https://bandit.readthedocs.io/en/{bandit.__version__}/"
+
     # NOTE(tkelsey): for some reason this import can't be found when stevedore
     # loads up the formatter plugin that imports this file. It is available
     # later though.
@@ -15,7 +17,7 @@ def get_url(bid):
     info = extension_loader.MANAGER.plugins_by_id.get(bid)
     if info is not None:
         return "{}plugins/{}_{}.html".format(
-            BASE_URL,
+            base_url,
             bid.lower(),
             info.plugin.__name__,
         )
@@ -51,6 +53,6 @@ def get_url(bid):
                 kind="imports", id=info["id"], name=info["name"]
             )
 
-        return BASE_URL + ext.lower()
+        return base_url + ext.lower()
 
-    return BASE_URL  # no idea, give the docs main page
+    return base_url  # no idea, give the docs main page

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ description_file =
     README.rst
 author = PyCQA
 author_email = code-quality@python.org
-home_page = https://bandit.readthedocs.io/en/latest/
+home_page = https://bandit.readthedocs.io/
 license = Apache-2.0 license
 classifier =
     Development Status :: 5 - Production/Stable

--- a/tests/unit/core/test_docs_util.py
+++ b/tests/unit/core/test_docs_util.py
@@ -3,26 +3,28 @@
 # SPDX-License-Identifier: Apache-2.0
 import testtools
 
-from bandit.core.docs_utils import BASE_URL
+import bandit
 from bandit.core.docs_utils import get_url
 
 
 class DocsUtilTests(testtools.TestCase):
     """This set of tests exercises bandit.core.docs_util functions."""
 
+    BASE_URL = f"https://bandit.readthedocs.io/en/{bandit.__version__}/"
+
     def test_overwrite_bib_info(self):
-        expected_url = BASE_URL + (
+        expected_url = self.BASE_URL + (
             "blacklists/blacklist_calls.html" "#b304-b305-ciphers-and-modes"
         )
         self.assertEqual(get_url("B304"), get_url("B305"))
         self.assertEqual(expected_url, get_url("B304"))
 
     def test_plugin_call_bib(self):
-        expected_url = BASE_URL + "plugins/b101_assert_used.html"
+        expected_url = self.BASE_URL + "plugins/b101_assert_used.html"
         self.assertEqual(expected_url, get_url("B101"))
 
     def test_import_call_bib(self):
-        expected_url = BASE_URL + (
+        expected_url = self.BASE_URL + (
             "blacklists/blacklist_imports.html" "#b413-import-pycrypto"
         )
         self.assertEqual(expected_url, get_url("B413"))


### PR DESCRIPTION
In the report of a Bandit run, there are links to the docs as
part of the more information. Today, these links are always
to the latest docs. So depending on the version of Bandit you're
running, these links could contain inaccurate information for
that version.

That's why this change makes it so a specific version of Bandit
is pinned to refer to a specific version of documentation.

Signed-off-by: Eric Brown <browne@vmware.com>