### PR TITLE
Fix line range using Python 3.8 end_lineno

### DIFF
--- a/bandit/core/node_visitor.py
+++ b/bandit/core/node_visitor.py
@@ -172,9 +172,7 @@ class BanditNodeVisitor:
         """
         self.context["str"] = node.s
         if not isinstance(node._bandit_parent, ast.Expr):  # docstring
-            self.context["linerange"] = b_utils.linerange_fix(
-                node._bandit_parent
-            )
+            self.context["linerange"] = b_utils.linerange(node._bandit_parent)
             self.update_scores(self.tester.run_tests(self.context, "Str"))
 
     def visit_Bytes(self, node):
@@ -187,9 +185,7 @@ class BanditNodeVisitor:
         """
         self.context["bytes"] = node.s
         if not isinstance(node._bandit_parent, ast.Expr):  # docstring
-            self.context["linerange"] = b_utils.linerange_fix(
-                node._bandit_parent
-            )
+            self.context["linerange"] = b_utils.linerange(node._bandit_parent)
             self.update_scores(self.tester.run_tests(self.context, "Bytes"))
 
     def pre_visit(self, node):
@@ -215,7 +211,7 @@ class BanditNodeVisitor:
             self.context["col_offset"] = node.col_offset
 
         self.context["node"] = node
-        self.context["linerange"] = b_utils.linerange_fix(node)
+        self.context["linerange"] = b_utils.linerange(node)
         self.context["filename"] = self.fname
         self.context["file_data"] = self.fdata
 

--- a/examples/multiline_statement.py
+++ b/examples/multiline_statement.py
@@ -4,3 +4,10 @@ subprocess.check_output("/some_command",
                         "args",
                         shell=True,
                         universal_newlines=True)
+
+subprocess.check_output(
+    "/some_command",
+    "args",
+    shell=True,
+    universal_newlines=True
+)

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -738,17 +738,25 @@ class FunctionalTests(testtools.TestCase):
         )
 
         issues = self.b_mgr.get_issue_list()
-        self.assertEqual(2, len(issues))
+        self.assertEqual(3, len(issues))
         self.assertTrue(
             issues[0].fname.endswith("examples/multiline_statement.py")
         )
-
         self.assertEqual(1, issues[0].lineno)
-        self.assertEqual(list(range(1, 3)), issues[0].linerange)
+        if sys.version_info >= (3, 8):
+            self.assertEqual(list(range(1, 2)), issues[0].linerange)
+        else:
+            self.assertEqual(list(range(1, 3)), issues[0].linerange)
         self.assertIn("subprocess", issues[0].get_code())
         self.assertEqual(5, issues[1].lineno)
         self.assertEqual(list(range(3, 6 + 1)), issues[1].linerange)
         self.assertIn("shell=True", issues[1].get_code())
+        self.assertEqual(11, issues[2].lineno)
+        if sys.version_info >= (3, 8):
+            self.assertEqual(list(range(8, 13 + 1)), issues[2].linerange)
+        else:
+            self.assertEqual(list(range(8, 12 + 1)), issues[2].linerange)
+        self.assertIn("shell=True", issues[2].get_code())
 
     def test_code_line_numbers(self):
         self.run_example("binding.py")


### PR DESCRIPTION
Python 3.8 and above have new ast node attributes to identify the
end line number and end column offset [1].

Python 3.8 also fixes line numbers for multiline strings [2].

This fixes the issue mentioned in #820, but only for Python 3.8+.

[1] https://docs.python.org/3.8/library/ast.html#ast.AST.end_lineno
[2] https://bugs.python.org/issue31241

Signed-off-by: Eric Brown <browne@vmware.com>