### PR TITLE
Group location line with code output

### DIFF
--- a/bandit/formatters/screen.py
+++ b/bandit/formatters/screen.py
@@ -17,8 +17,8 @@ This formatter outputs the issues as color coded text to screen.
 
        Severity: Medium   Confidence: High
        CWE: CWE-20 (https://cwe.mitre.org/data/definitions/20.html)
-       Location: examples/yaml_load.py:5
        More Info: https://bandit.readthedocs.io/en/latest/
+       Location: examples/yaml_load.py:5
     4       ystr = yaml.dump({'a' : 1, 'b' : 2, 'c' : 3})
     5       y = yaml.load(ystr)
     6       yaml.dump(y)
@@ -128,19 +128,17 @@ def _output_issue_str(
 
     bits.append(f"{indent}   CWE: {str(issue.cwe)}")
 
+    bits.append(f"{indent}   More Info: {docs_utils.get_url(issue.test_id)}")
+
     bits.append(
-        "%s   Location: %s:%s:%s"
+        "%s   Location: %s:%s:%s%s"
         % (
             indent,
             issue.fname,
             issue.lineno if show_lineno else "",
             issue.col_offset if show_lineno else "",
+            COLOR["DEFAULT"],
         )
-    )
-
-    bits.append(
-        "%s   More Info: %s%s"
-        % (indent, docs_utils.get_url(issue.test_id), COLOR["DEFAULT"])
     )
 
     if show_code:

--- a/bandit/formatters/text.py
+++ b/bandit/formatters/text.py
@@ -16,8 +16,9 @@ This formatter outputs the issues as plain text.
        instantiation of arbitrary objects. Consider yaml.safe_load().
 
        Severity: Medium   Confidence: High
-       Location: examples/yaml_load.py:5
+       CWE: CWE-20 (https://cwe.mitre.org/data/definitions/20.html)
        More Info: https://bandit.readthedocs.io/en/latest/
+       Location: examples/yaml_load.py:5
     4       ystr = yaml.dump({'a' : 1, 'b' : 2, 'c' : 3})
     5       y = yaml.load(ystr)
     6       yaml.dump(y)
@@ -95,6 +96,8 @@ def _output_issue_str(
 
     bits.append(f"{indent}   CWE: {str(issue.cwe)}")
 
+    bits.append(f"{indent}   More Info: {docs_utils.get_url(issue.test_id)}")
+
     bits.append(
         "%s   Location: %s:%s:%s"
         % (
@@ -104,8 +107,6 @@ def _output_issue_str(
             issue.col_offset if show_lineno else "",
         )
     )
-
-    bits.append(f"{indent}   More Info: {docs_utils.get_url(issue.test_id)}")
 
     if show_code:
         bits.extend(

--- a/tests/unit/formatters/test_screen.py
+++ b/tests/unit/formatters/test_screen.py
@@ -44,12 +44,15 @@ class ScreenFormatterTests(testtools.TestCase):
                     _indent_val,
                     _issue.cwe,
                 ),
-                "{}   Location: {}:{}:{}".format(
-                    _indent_val, _issue.fname, _issue.lineno, _issue.col_offset
-                ),
-                "{}   More Info: {}{}".format(
+                "{}   More Info: {}".format(
                     _indent_val,
                     docs_utils.get_url(_issue.test_id),
+                ),
+                "{}   Location: {}:{}:{}{}".format(
+                    _indent_val,
+                    _issue.fname,
+                    _issue.lineno,
+                    _issue.col_offset,
                     screen.COLOR["DEFAULT"],
                 ),
             ]

--- a/tests/unit/formatters/test_text.py
+++ b/tests/unit/formatters/test_text.py
@@ -37,11 +37,11 @@ class TextFormatterTests(testtools.TestCase):
                     _issue.confidence.capitalize(),
                 ),
                 f"{_indent_val}   CWE: {_issue.cwe}",
-                "{}   Location: {}:{}:{}".format(
-                    _indent_val, _issue.fname, _issue.lineno, _issue.col_offset
-                ),
                 "{}   More Info: {}".format(
                     _indent_val, docs_utils.get_url(_issue.test_id)
+                ),
+                "{}   Location: {}:{}:{}".format(
+                    _indent_val, _issue.fname, _issue.lineno, _issue.col_offset
                 ),
             ]
             if _code:


### PR DESCRIPTION
Currently for the screen and text formatters there is a More Info
line in between the Location line and the code snippet lines.

This change puts the Location with the code snippet as a more
logical grouping of code location information.

Signed-off-by: Eric Brown <browne@vmware.com>