### PR TITLE
Center the bandit logo in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,8 @@
-.. image:: https://github.com/PyCQA/bandit/blob/main/logo/logotype-sm.png
-    :alt: Bandit
+.. raw:: html
+
+    <p align="center">
+        <img src="https://raw.githubusercontent.com/pycqa/bandit/main/logo/logotype-sm.png" alt="Bandit">
+    </p>
 
 ======
 


### PR DESCRIPTION
Minor nit change to center the logo in the readme for more visual
appeal.

Signed-off-by: Eric Brown <browne@vmware.com>