### PR TITLE
Replace `toml` with `tomli`

### DIFF
--- a/bandit/core/config.py
+++ b/bandit/core/config.py
@@ -7,9 +7,9 @@ import logging
 import yaml
 
 try:
-    import toml
+    import tomli
 except ImportError:
-    toml = None
+    tomli = None
 
 from bandit.core import constants
 from bandit.core import extension_loader
@@ -34,14 +34,14 @@ class BanditConfig:
 
         if config_file:
             try:
-                f = open(config_file)
+                f = open(config_file, "rb")
             except OSError:
                 raise utils.ConfigError(
                     "Could not read config file.", config_file
                 )
 
             if config_file.endswith(".toml"):
-                if toml is None:
+                if tomli is None:
                     raise utils.ConfigError(
                         "toml parser not available, reinstall with toml extra",
                         config_file,
@@ -49,8 +49,8 @@ class BanditConfig:
 
                 try:
                     with f:
-                        self._config = toml.load(f)["tool"]["bandit"]
-                except toml.TomlDecodeError as err:
+                        self._config = tomli.load(f)["tool"]["bandit"]
+                except tomli.TOMLDecodeError as err:
                     LOG.error(err)
                     raise utils.ConfigError("Error parsing file.", config_file)
             else:

--- a/bandit/core/config.py
+++ b/bandit/core/config.py
@@ -3,13 +3,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import logging
+import sys
 
 import yaml
 
-try:
-    import tomli
-except ImportError:
-    tomli = None
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    try:
+        import tomli as tomllib
+    except ImportError:
+        tomllib = None
 
 from bandit.core import constants
 from bandit.core import extension_loader
@@ -41,7 +45,7 @@ class BanditConfig:
                 )
 
             if config_file.endswith(".toml"):
-                if tomli is None:
+                if tomllib is None:
                     raise utils.ConfigError(
                         "toml parser not available, reinstall with toml extra",
                         config_file,
@@ -49,8 +53,8 @@ class BanditConfig:
 
                 try:
                     with f:
-                        self._config = tomli.load(f)["tool"]["bandit"]
-                except tomli.TOMLDecodeError as err:
+                        self._config = tomllib.load(f)["tool"]["bandit"]
+                except tomllib.TOMLDecodeError as err:
                     LOG.error(err)
                     raise utils.ConfigError("Error parsing file.", config_file)
             else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ project_urls =
 yaml =
     PyYAML
 toml =
-    tomli>=1.1.0
+    tomli>=1.1.0; python_version < "3.11"
 
 [entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ project_urls =
 yaml =
     PyYAML
 toml =
-    toml
+    tomli>=1.1.0
 
 [entry_points]
 console_scripts =

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,6 +7,6 @@ flake8>=4.0.0 # Apache-2.0
 stestr>=2.5.0 # Apache-2.0
 testscenarios>=0.5.0 # Apache-2.0/BSD
 testtools>=2.3.0 # MIT
-tomli>=1.1.0 # MIT
+tomli>=1.1.0;python_version<"3.11" # MIT
 beautifulsoup4>=4.8.0 # MIT
 pylint==1.9.4 # GPLv2

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,6 +7,6 @@ flake8>=4.0.0 # Apache-2.0
 stestr>=2.5.0 # Apache-2.0
 testscenarios>=0.5.0 # Apache-2.0/BSD
 testtools>=2.3.0 # MIT
-toml # MIT
+tomli>=1.1.0 # MIT
 beautifulsoup4>=4.8.0 # MIT
 pylint==1.9.4 # GPLv2


### PR DESCRIPTION
Resolves #828 

Replace `toml` with `tomli` for parsing bandit options defined in `pyproject.toml`.

The reason for requiring at least `1.1.0` is because support for text files has been [deprecated in 1.2.0](https://github.com/hukkin/tomli/blob/d21aa80b441fb46361386c44f92985b4921b9b8b/CHANGELOG.md#120) then [removed in 2.0.0](https://github.com/hukkin/tomli/blob/d21aa80b441fb46361386c44f92985b4921b9b8b/CHANGELOG.md#200), and support for binary files has only been [added in 1.1.0](https://github.com/hukkin/tomli/blob/d21aa80b441fb46361386c44f92985b4921b9b8b/CHANGELOG.md#110), so this ensures that users have `1.1.0+`, to reliably be able to read binary files.

As `tomli` only reads binary files, it is required to open the file using `rb` flags, which also impacts the format passed to `safe_load` for YAML files, but `PyYAML` accepts both binary and text files, so this still works as expected, though this may slow down a bit parsing time.