### PR TITLE
Target Python >= 3.7 in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,17 +11,17 @@ repos:
   rev: v2.6.0
   hooks:
   - id: reorder-python-imports
-    args: [--application-directories, '.:src', --py36-plus]
+    args: [--application-directories, '.:src', --py37-plus]
 - repo: https://github.com/psf/black
   rev: 21.10b0
   hooks:
   - id: black
-    args: [--line-length=79, --target-version=py36]
+    args: [--line-length=79, --target-version=py37]
 - repo: https://github.com/asottile/pyupgrade
   rev: v2.29.0
   hooks:
   - id: pyupgrade
-    args: [--py36-plus]
+    args: [--py37-plus]
 - repo: https://github.com/jorisroovers/gitlint
   rev: v0.16.0
   hooks:


### PR DESCRIPTION
Support for Python 3.6 has been removed in https://github.com/PyCQA/bandit/pull/777, so it looks like pre-commit hooks could get updated to target Python >= 3.7 instead of 3.6.