### PR TITLE
Build of artifact fails if raw directive used

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,5 @@
-.. raw:: html
-
-    <p align="center">
-        <img src="https://raw.githubusercontent.com/pycqa/bandit/main/logo/logotype-sm.png" alt="Bandit">
-    </p>
+.. image:: https://raw.githubusercontent.com/pycqa/bandit/main/logo/logotype-sm.png
+    :alt: Bandit
 
 ======
 


### PR DESCRIPTION
A recent change to center the logo made use of the html raw keyword
in the README. Apparently this fails when building the Bandit artifact.

```
Checking dist/bandit-1.7.3.dev33-py3-none-any.whl: FAILED
`long_description` has syntax errors in markup and would not be rendered on PyPI.

line 1: Warning: "raw" directive disabled.
warning: `long_description_content_type` missing. defaulting to `text/x-rst`.
```
This change reverts the centering, but keeps the updated link.

Signed-off-by: Eric Brown <browne@vmware.com>