### PR TITLE
Add version 1.7.3 to dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -44,7 +44,8 @@ body:
       label: Bandit version
       description: Run "bandit --version" if unsure of version number
       options:
-        - 1.7.2 (Default)
+        - 1.7.3 (Default)
+        - 1.7.2
         - 1.7.1
         - 1.7.0
         - 1.6.3


### PR DESCRIPTION
Add an option for newly released version 1.7.3 for the user to report a bug on.