### PR TITLE
Replace pbr in favor of importlib

### DIFF
--- a/bandit/__init__.py
+++ b/bandit/__init__.py
@@ -2,7 +2,7 @@
 # Copyright 2014 Hewlett-Packard Development Company, L.P.
 #
 # SPDX-License-Identifier: Apache-2.0
-import pbr.version
+from importlib import metadata
 
 from bandit.core import config  # noqa
 from bandit.core import context  # noqa
@@ -16,4 +16,4 @@ from bandit.core.constants import *  # noqa
 from bandit.core.issue import *  # noqa
 from bandit.core.test_properties import *  # noqa
 
-__version__ = pbr.version.VersionInfo("bandit").version_string()
+__version__ = metadata.version("bandit")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ GitPython>=1.0.1 # BSD License (3 clause)
 PyYAML>=5.3.1 # MIT
 stevedore>=1.20.0 # Apache-2.0
 colorama>=0.3.9;platform_system=="Windows" # BSD License (3 clause)
+importlib-metadata;python_version<"3.8" # Apache-2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -137,8 +137,3 @@ bandit.plugins =
 all_files = 1
 build-dir = doc/build
 source-dir = doc/source
-
-[pbr]
-autodoc_tree_index_modules = True
-autodoc_tree_excludes =
-  examples*

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,4 @@
 import setuptools
 
 
-setuptools.setup(
-    python_requires=">=3.7", setup_requires=["pbr>=2.0.0"], pbr=True
-)
+setuptools.setup(python_requires=">=3.7")


### PR DESCRIPTION
The importlib module has a metadata.version to retrieve the package
version of the given module. This can be used in lieu of pbr for
gathering versioning. And since importlib is part of the base
Python package in 3.8 and greater, we can drop another dependency.

Closes #839

Signed-off-by: Eric Brown <browne@vmware.com>