### PR TITLE
core/config: Fix ConfigError missing argument if toml is missing

### DIFF
--- a/bandit/core/config.py
+++ b/bandit/core/config.py
@@ -43,7 +43,8 @@ class BanditConfig:
             if config_file.endswith(".toml"):
                 if toml is None:
                     raise utils.ConfigError(
-                        "toml parser not available, reinstall with toml extra"
+                        "toml parser not available, reinstall with toml extra",
+                        config_file,
                     )
 
                 try:


### PR DESCRIPTION
Fixes the following error:

    Traceback (most recent call last):
      File "bin/bandit", line 8, in <module>
        sys.exit(main())
      File "lib/python3.10/site-packages/bandit/cli/main.py", line 455, in main
        b_conf = b_config.BanditConfig(config_file=args.config_file)
      File "lib/python3.10/site-packages/bandit/core/config.py", line 45, in __init__
        raise utils.ConfigError(
    TypeError: ConfigError.__init__() missing 1 required positional argument: 'config_file'