### PR TITLE
Add 1.7.4 in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -44,7 +44,8 @@ body:
       label: Bandit version
       description: Run "bandit --version" if unsure of version number
       options:
-        - 1.7.3 (Default)
+        - 1.7.4 (Default)
+        - 1.7.3
         - 1.7.2
         - 1.7.1
         - 1.7.0


### PR DESCRIPTION
Add an option for version 1.7.4 in the bug report in preparation for a new release of 1.7.4 afterwards.