### PR TITLE
Add classifier to indicate Py3 only

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifier =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3 :: Only
     Topic :: Security
 project_urls =
     Release notes = https://github.com/PyCQA/bandit/releases


### PR DESCRIPTION
PyPI has a classifier to specifically state that only Python 3.x is supported (as opposed to 2.x).

https://pypi.org/pypi?%3Aaction=list_classifiers