### PR TITLE
Removal of blacklist call B309 httpsconnection

### DIFF
--- a/bandit/blacklists/calls.py
+++ b/bandit/blacklists/calls.py
@@ -137,6 +137,8 @@ be reviewed.
 B309: httpsconnection
 ---------------------
 
+The check for this call has been removed.
+
 Use of HTTPSConnection on older versions of Python prior to 2.7.9 and 3.4.3 do
 not provide security, see https://wiki.openstack.org/wiki/OSSN/OSSN-0033
 
@@ -479,21 +481,7 @@ def gen_blacklist():
         )
     )
 
-    sets.append(
-        utils.build_conf_dict(
-            "httpsconnection",
-            "B309",
-            issue.Cwe.CLEARTEXT_TRANSMISSION,
-            [
-                "httplib.HTTPSConnection",
-                "http.client.HTTPSConnection",
-                "six.moves.http_client.HTTPSConnection",
-            ],
-            "Use of HTTPSConnection on older versions of Python prior to 2.7.9"
-            " and 3.4.3 do not provide security, see "
-            "https://wiki.openstack.org/wiki/OSSN/OSSN-0033",
-        )
-    )
+    # skipped B309 as the check for a call to httpsconnection has been removed
 
     sets.append(
         utils.build_conf_dict(

--- a/examples/httplib_https.py
+++ b/examples/httplib_https.py
@@ -1,8 +1,0 @@
-import httplib
-c = httplib.HTTPSConnection("example.com")
-
-import http.client
-c = http.client.HTTPSConnection("example.com")
-
-import six
-six.moves.http_client.HTTPSConnection("example.com")

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -196,14 +196,6 @@ class FunctionalTests(testtools.TestCase):
         }
         self.check_example("hardcoded-tmp.py", expect)
 
-    def test_httplib_https(self):
-        """Test for `httplib.HTTPSConnection`."""
-        expect = {
-            "SEVERITY": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 3, "HIGH": 0},
-            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 3},
-        }
-        self.check_example("httplib_https.py", expect)
-
     def test_imports_aliases(self):
         """Test the `import X as Y` syntax."""
         if sys.version_info >= (3, 9):


### PR DESCRIPTION
This check existed because of insufficient checking of certificates
when using httpsconnection. Since 3.4.3, this has been fixed. And
since Bandit supports 3.7+, there is no longer a need to scan for
this.

Closes #857

Signed-off-by: Eric Brown <browne@vmware.com>