### PR TITLE
Indiciate hash type in message

### DIFF
--- a/bandit/plugins/hashlib_insecure_functions.py
+++ b/bandit/plugins/hashlib_insecure_functions.py
@@ -63,8 +63,8 @@ def _hashlib_func(context):
                         severity=bandit.HIGH,
                         confidence=bandit.HIGH,
                         cwe=issue.Cwe.BROKEN_CRYPTO,
-                        text="Use of weak MD4, MD5, or SHA1 hash for "
-                        "security. Consider usedforsecurity=False",
+                        text=f"Use of weak {func.upper()} hash for security. "
+                        "Consider usedforsecurity=False",
                         lineno=context.node.lineno,
                     )
             elif func == "new":
@@ -76,7 +76,7 @@ def _hashlib_func(context):
                             severity=bandit.HIGH,
                             confidence=bandit.HIGH,
                             cwe=issue.Cwe.BROKEN_CRYPTO,
-                            text="Use of weak MD4, MD5, or SHA1 hash for "
+                            text=f"Use of weak {name.upper()} hash for "
                             "security. Consider usedforsecurity=False",
                             lineno=context.node.lineno,
                         )
@@ -96,7 +96,7 @@ def _hashlib_new(context):
                     severity=bandit.MEDIUM,
                     confidence=bandit.HIGH,
                     cwe=issue.Cwe.BROKEN_CRYPTO,
-                    text="Use of insecure MD4, MD5, or SHA1 hash function.",
+                    text=f"Use of insecure {name.upper()} hash function.",
                     lineno=context.node.lineno,
                 )
 


### PR DESCRIPTION
Instead of a message telling the user the possible weak hashlib
functions in use, this change indicates to the user the exact
hash that is being used.

Signed-off-by: Eric Brown <browne@vmware.com>