### PR TITLE
Add the httpx module check for verify

### DIFF
--- a/bandit/plugins/crypto_request_no_cert_validation.py
+++ b/bandit/plugins/crypto_request_no_cert_validation.py
@@ -13,17 +13,17 @@ identity of the party you are communicating with.  This is accomplished by one
 or both parties presenting trusted certificates during the connection
 initialization phase of TLS.
 
-When request methods are used certificates are validated automatically which is
-the desired behavior.  If certificate validation is explicitly turned off
-Bandit will return a HIGH severity error.
+When HTTPS request methods are used, certificates are validated automatically
+which is the desired behavior.  If certificate validation is explicitly turned
+off Bandit will return a HIGH severity error.
 
 
 :Example:
 
 .. code-block:: none
 
-    >> Issue: [request_with_no_cert_validation] Requests call with verify=False
-    disabling SSL certificate checks, security issue.
+    >> Issue: [request_with_no_cert_validation] Call to requests with
+    verify=False disabling SSL certificate checks, security issue.
        Severity: High   Confidence: High
        CWE: CWE-295 (https://cwe.mitre.org/data/definitions/295.html)
        Location: examples/requests-ssl-verify-disabled.py:4
@@ -42,6 +42,9 @@ Bandit will return a HIGH severity error.
 .. versionchanged:: 1.7.3
     CWE information added
 
+.. versionchanged:: 1.7.5
+    Added check for httpx module
+
 """
 import bandit
 from bandit.core import issue
@@ -51,17 +54,22 @@ from bandit.core import test_properties as test
 @test.checks("Call")
 @test.test_id("B501")
 def request_with_no_cert_validation(context):
-    http_verbs = ("get", "options", "head", "post", "put", "patch", "delete")
+    HTTP_VERBS = ("get", "options", "head", "post", "put", "patch", "delete")
+    HTTPX_ATTRS = ("request", "stream", "Client", "AsyncClient") + HTTP_VERBS
+    qualname = context.call_function_name_qual.split(".")[0]
+
     if (
-        "requests" in context.call_function_name_qual
-        and context.call_function_name in http_verbs
+        qualname == "requests"
+        and context.call_function_name in HTTP_VERBS
+        or qualname == "httpx"
+        and context.call_function_name in HTTPX_ATTRS
     ):
         if context.check_call_arg_value("verify", "False"):
             return bandit.Issue(
                 severity=bandit.HIGH,
                 confidence=bandit.HIGH,
                 cwe=issue.Cwe.IMPROPER_CERT_VALIDATION,
-                text="Requests call with verify=False disabling SSL "
+                text=f"Call to {qualname} with verify=False disabling SSL "
                 "certificate checks, security issue.",
                 lineno=context.get_lineno_for_call_arg("verify"),
             )

--- a/examples/requests-ssl-verify-disabled.py
+++ b/examples/requests-ssl-verify-disabled.py
@@ -1,4 +1,6 @@
+import httpx
 import requests
+
 
 requests.get('https://gmail.com', verify=True)
 requests.get('https://gmail.com', verify=False)
@@ -14,3 +16,26 @@ requests.options('https://gmail.com', verify=True)
 requests.options('https://gmail.com', verify=False)
 requests.head('https://gmail.com', verify=True)
 requests.head('https://gmail.com', verify=False)
+
+httpx.request('GET', 'https://gmail.com', verify=True)
+httpx.request('GET', 'https://gmail.com', verify=False)
+httpx.get('https://gmail.com', verify=True)
+httpx.get('https://gmail.com', verify=False)
+httpx.options('https://gmail.com', verify=True)
+httpx.options('https://gmail.com', verify=False)
+httpx.head('https://gmail.com', verify=True)
+httpx.head('https://gmail.com', verify=False)
+httpx.post('https://gmail.com', verify=True)
+httpx.post('https://gmail.com', verify=False)
+httpx.put('https://gmail.com', verify=True)
+httpx.put('https://gmail.com', verify=False)
+httpx.patch('https://gmail.com', verify=True)
+httpx.patch('https://gmail.com', verify=False)
+httpx.delete('https://gmail.com', verify=True)
+httpx.delete('https://gmail.com', verify=False)
+httpx.stream('https://gmail.com', verify=True)
+httpx.stream('https://gmail.com', verify=False)
+httpx.Client()
+httpx.Client(verify=False)
+httpx.AsyncClient()
+httpx.AsyncClient(verify=False)

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -388,8 +388,8 @@ class FunctionalTests(testtools.TestCase):
     def test_requests_ssl_verify_disabled(self):
         """Test for the `requests` library skipping verification."""
         expect = {
-            "SEVERITY": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 7},
-            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 7},
+            "SEVERITY": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 18},
+            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 18},
         }
         self.check_example("requests-ssl-verify-disabled.py", expect)
 


### PR DESCRIPTION
The httpx module functions very similar to requests in that there
is a verify argument to indicate whether to verify the certificate
of the host it's connecting with.

As such, this plugin has been modified to include httpx in addition
to requests for cases whether verify=False.

Signed-off-by: Eric Brown <browne@vmware.com>