### PR TITLE
Add doc for hashlib plugin

### DIFF
--- a/doc/source/plugins/b324_hashlib.rst
+++ b/doc/source/plugins/b324_hashlib.rst
@@ -1,0 +1,5 @@
+-------------
+B324: hashlib
+-------------
+
+.. automodule:: bandit.plugins.hashlib_insecure_functions


### PR DESCRIPTION
The hashlib_insecure_functions module is missing documentation. More
than likely this is a result of having checks in blacklist for hashlib
and also a plugin. The blacklists have a reserved Id range of 3xx, which
is what this plugin is using.

Near term, this change publishes a page for B324 hashlib plugin. Longer
term, the bandit Id should be migrated out of the 3xx group to something
more appropriate.

Closes #559

Signed-off-by: Eric Brown <browne@vmware.com>