### PR TITLE
Fix up B109 and B111 removed plugins docs

### DIFF
--- a/doc/source/plugins/b109_password_config_option_not_marked_secret.rst
+++ b/doc/source/plugins/b109_password_config_option_not_marked_secret.rst
@@ -1,8 +1,10 @@
----------------------------------------------------------------
-B109: Test for a password based config option not marked secret
----------------------------------------------------------------
+----------------------------------------------
+B109: password_config_option_not_marked_secret
+----------------------------------------------
 
 This plugin has been removed.
+
+B109: Test for a password based config option not marked secret
 
 Passwords are sensitive and must be protected appropriately. In OpenStack
 Oslo there is an option to mark options "secret" which will ensure that they
@@ -14,3 +16,43 @@ If such a value is found a MEDIUM severity error is generated. If 'False' or
 'None' are explicitly set, Bandit will return a MEDIUM confidence issue. If
 Bandit can't determine the value of secret it will return a LOW confidence
 issue.
+
+
+**Config Options:**
+.. code-block:: yaml
+    password_config_option_not_marked_secret:
+        function_names:
+            - oslo.config.cfg.StrOpt
+            - oslo_config.cfg.StrOpt
+
+:Example:
+
+.. code-block:: none
+
+    >> Issue: [password_config_option_not_marked_secret] oslo config option
+    possibly not marked secret=True identified.
+       Severity: Medium   Confidence: Low
+       Location: examples/secret-config-option.py:12
+    11                  help="User's password"),
+    12       cfg.StrOpt('nova_password',
+    13                  secret=secret,
+    14                  help="Nova user password"),
+    15   ]
+
+    >> Issue: [password_config_option_not_marked_secret] oslo config option not
+    marked secret=True identified, security issue.
+       Severity: Medium   Confidence: Medium
+       Location: examples/secret-config-option.py:21
+    20                  help="LDAP ubind ser name"),
+    21       cfg.StrOpt('ldap_password',
+    22                  help="LDAP bind user password"),
+    23       cfg.StrOpt('ldap_password_attribute',
+
+.. seealso::
+
+ - https://security.openstack.org/guidelines/dg_protect-sensitive-data-in-files.html
+
+.. versionadded:: 0.10.0
+
+.. deprecated:: 1.5.0
+   This plugin was removed

--- a/doc/source/plugins/b111_execute_with_run_as_root_equals_true.rst
+++ b/doc/source/plugins/b111_execute_with_run_as_root_equals_true.rst
@@ -1,11 +1,54 @@
---------------------------------------------------
-B111: Test for the use of rootwrap running as root
---------------------------------------------------
+------------------------------------------
+B111: execute_with_run_as_root_equals_true
+------------------------------------------
 
 This plugin has been removed.
+
+B111: Test for the use of rootwrap running as root
 
 Running commands as root dramatically increase their potential risk. Running
 commands with restricted user privileges provides defense in depth against
 command injection attacks, or developer and configuration error. This plugin
 test checks for specific methods being called with a keyword parameter
 `run_as_root` set to True, a common OpenStack idiom.
+
+
+**Config Options:**
+
+This test plugin takes a similarly named configuration block,
+`execute_with_run_as_root_equals_true`, providing a list, `function_names`, of
+function names. A call to any of these named functions will be checked for a
+`run_as_root` keyword parameter, and if True, will report a Low severity
+issue.
+
+.. code-block:: yaml
+
+    execute_with_run_as_root_equals_true:
+        function_names:
+            - ceilometer.utils.execute
+            - cinder.utils.execute
+            - neutron.agent.linux.utils.execute
+            - nova.utils.execute
+            - nova.utils.trycmd
+
+:Example:
+
+.. code-block:: none
+
+    >> Issue: Execute with run_as_root=True identified, possible security
+       issue.
+       Severity: Low   Confidence: Medium
+       Location: ./examples/exec-as-root.py:26
+    25  nova_utils.trycmd('gcc --version')
+    26  nova_utils.trycmd('gcc --version', run_as_root=True)
+    27
+
+.. seealso::
+
+ - https://security.openstack.org/guidelines/dg_rootwrap-recommendations-and-plans.html
+ - https://security.openstack.org/guidelines/dg_use-oslo-rootwrap-securely.html
+
+.. versionadded:: 0.10.0
+
+.. deprecated:: 1.5.0
+   This plugin was removed


### PR DESCRIPTION
The B109 and B111 plugins were removed in 1.5.0 and the docs only
referenced them for historical information.

This change fixes the titles to be what they were originally and
adds the complete doc and indicates deprecated and removed in
1.5.0.

Closes #367

Signed-off-by: Eric Brown <browne@vmware.com>