### PR TITLE
Fix for build breaks in format job

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
   - id: reorder-python-imports
     args: [--application-directories, '.:src', --py37-plus]
 - repo: https://github.com/psf/black
-  rev: 21.10b0
+  rev: 22.3.0
   hooks:
   - id: black
     args: [--line-length=79, --target-version=py37]


### PR DESCRIPTION
This change bumps the version of Black in use to fix the errors
seen coming out of the format build step.

See https://github.com/psf/black/issues/2964

Signed-off-by: Eric Brown <browne@vmware.com>