### PR TITLE
Add a Discord link to the docs

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -23,9 +23,11 @@ Contributing
 
 * `Source code`_
 * `Issue tracker`_
+* Join us on `Discord`_
 
 .. _`Source code`: https://github.com/PyCQA/bandit
 .. _`Issue tracker`: https://github.com/PyCQA/bandit/issues
+.. _`Discord`: https://discord.gg/qYxpadCgkx
 
 Indices and tables
 ==================


### PR DESCRIPTION
This change adds a Discord link to our docs in the contributing
section so users know where they can reach out for questions
and discussion.

Closes #775

Signed-off-by: Eric Brown <browne@vmware.com>