### PR TITLE
Use a table format for list of plugins

### DIFF
--- a/doc/source/plugins/b101_assert_used.rst
+++ b/doc/source/plugins/b101_assert_used.rst
@@ -1,5 +1,5 @@
------------------
-B101: assert_used
------------------
+-----------
+assert_used
+-----------
 
 .. automodule:: bandit.plugins.asserts

--- a/doc/source/plugins/b102_exec_used.rst
+++ b/doc/source/plugins/b102_exec_used.rst
@@ -1,5 +1,5 @@
----------------
-B102: exec_used
----------------
+---------
+exec_used
+---------
 
 .. automodule:: bandit.plugins.exec

--- a/doc/source/plugins/b103_set_bad_file_permissions.rst
+++ b/doc/source/plugins/b103_set_bad_file_permissions.rst
@@ -1,5 +1,5 @@
-------------------------------
-B103: set_bad_file_permissions
-------------------------------
+------------------------
+set_bad_file_permissions
+------------------------
 
 .. automodule:: bandit.plugins.general_bad_file_permissions

--- a/doc/source/plugins/b104_hardcoded_bind_all_interfaces.rst
+++ b/doc/source/plugins/b104_hardcoded_bind_all_interfaces.rst
@@ -1,5 +1,5 @@
------------------------------------
-B104: hardcoded_bind_all_interfaces
------------------------------------
+-----------------------------
+hardcoded_bind_all_interfaces
+-----------------------------
 
 .. automodule:: bandit.plugins.general_bind_all_interfaces

--- a/doc/source/plugins/b105_hardcoded_password_string.rst
+++ b/doc/source/plugins/b105_hardcoded_password_string.rst
@@ -1,6 +1,6 @@
--------------------------------
-B105: hardcoded_password_string
--------------------------------
+-------------------------
+hardcoded_password_string
+-------------------------
 
 .. currentmodule:: bandit.plugins.general_hardcoded_password
 

--- a/doc/source/plugins/b106_hardcoded_password_funcarg.rst
+++ b/doc/source/plugins/b106_hardcoded_password_funcarg.rst
@@ -1,6 +1,6 @@
---------------------------------
-B106: hardcoded_password_funcarg
---------------------------------
+--------------------------
+hardcoded_password_funcarg
+--------------------------
 
 .. currentmodule:: bandit.plugins.general_hardcoded_password
 

--- a/doc/source/plugins/b107_hardcoded_password_default.rst
+++ b/doc/source/plugins/b107_hardcoded_password_default.rst
@@ -1,6 +1,6 @@
---------------------------------
-B107: hardcoded_password_default
---------------------------------
+--------------------------
+hardcoded_password_default
+--------------------------
 
 .. currentmodule:: bandit.plugins.general_hardcoded_password
 

--- a/doc/source/plugins/b108_hardcoded_tmp_directory.rst
+++ b/doc/source/plugins/b108_hardcoded_tmp_directory.rst
@@ -1,5 +1,5 @@
------------------------------
-B108: hardcoded_tmp_directory
------------------------------
+-----------------------
+hardcoded_tmp_directory
+-----------------------
 
 .. automodule:: bandit.plugins.general_hardcoded_tmp

--- a/doc/source/plugins/b109_password_config_option_not_marked_secret.rst
+++ b/doc/source/plugins/b109_password_config_option_not_marked_secret.rst
@@ -1,6 +1,6 @@
-----------------------------------------------
-B109: password_config_option_not_marked_secret
-----------------------------------------------
+----------------------------------------
+password_config_option_not_marked_secret
+----------------------------------------
 
 This plugin has been removed.
 

--- a/doc/source/plugins/b110_try_except_pass.rst
+++ b/doc/source/plugins/b110_try_except_pass.rst
@@ -1,5 +1,5 @@
----------------------
-B110: try_except_pass
----------------------
+---------------
+try_except_pass
+---------------
 
 .. automodule:: bandit.plugins.try_except_pass

--- a/doc/source/plugins/b111_execute_with_run_as_root_equals_true.rst
+++ b/doc/source/plugins/b111_execute_with_run_as_root_equals_true.rst
@@ -1,6 +1,6 @@
-------------------------------------------
-B111: execute_with_run_as_root_equals_true
-------------------------------------------
+------------------------------------
+execute_with_run_as_root_equals_true
+------------------------------------
 
 This plugin has been removed.
 

--- a/doc/source/plugins/b112_try_except_continue.rst
+++ b/doc/source/plugins/b112_try_except_continue.rst
@@ -1,5 +1,5 @@
--------------------------
-B112: try_except_continue
--------------------------
+-------------------
+try_except_continue
+-------------------
 
 .. automodule:: bandit.plugins.try_except_continue

--- a/doc/source/plugins/b113_request_without_timeout.rst
+++ b/doc/source/plugins/b113_request_without_timeout.rst
@@ -1,5 +1,5 @@
------------------------------
-B113: request_without_timeout
------------------------------
+-----------------------
+request_without_timeout
+-----------------------
 
 .. automodule:: bandit.plugins.request_without_timeout

--- a/doc/source/plugins/b201_flask_debug_true.rst
+++ b/doc/source/plugins/b201_flask_debug_true.rst
@@ -1,5 +1,5 @@
-----------------------
-B201: flask_debug_true
-----------------------
+----------------
+flask_debug_true
+----------------
 
 .. automodule:: bandit.plugins.app_debug

--- a/doc/source/plugins/b324_hashlib.rst
+++ b/doc/source/plugins/b324_hashlib.rst
@@ -1,5 +1,5 @@
--------------
-B324: hashlib
--------------
+-------
+hashlib
+-------
 
 .. automodule:: bandit.plugins.hashlib_insecure_functions

--- a/doc/source/plugins/b501_request_with_no_cert_validation.rst
+++ b/doc/source/plugins/b501_request_with_no_cert_validation.rst
@@ -1,5 +1,5 @@
--------------------------------------
-B501: request_with_no_cert_validation
--------------------------------------
+-------------------------------
+request_with_no_cert_validation
+-------------------------------
 
 .. automodule:: bandit.plugins.crypto_request_no_cert_validation

--- a/doc/source/plugins/b502_ssl_with_bad_version.rst
+++ b/doc/source/plugins/b502_ssl_with_bad_version.rst
@@ -1,6 +1,6 @@
---------------------------
-B502: ssl_with_bad_version
---------------------------
+--------------------
+ssl_with_bad_version
+--------------------
 
 .. currentmodule:: bandit.plugins.insecure_ssl_tls
 

--- a/doc/source/plugins/b503_ssl_with_bad_defaults.rst
+++ b/doc/source/plugins/b503_ssl_with_bad_defaults.rst
@@ -1,6 +1,6 @@
----------------------------
-B503: ssl_with_bad_defaults
----------------------------
+---------------------
+ssl_with_bad_defaults
+---------------------
 
 .. currentmodule:: bandit.plugins.insecure_ssl_tls
 

--- a/doc/source/plugins/b504_ssl_with_no_version.rst
+++ b/doc/source/plugins/b504_ssl_with_no_version.rst
@@ -1,6 +1,6 @@
--------------------------
-B504: ssl_with_no_version
--------------------------
+-------------------
+ssl_with_no_version
+-------------------
 
 .. currentmodule:: bandit.plugins.insecure_ssl_tls
 

--- a/doc/source/plugins/b505_weak_cryptographic_key.rst
+++ b/doc/source/plugins/b505_weak_cryptographic_key.rst
@@ -1,5 +1,5 @@
-----------------------------
-B505: weak_cryptographic_key
-----------------------------
+----------------------
+weak_cryptographic_key
+----------------------
 
 .. automodule:: bandit.plugins.weak_cryptographic_key

--- a/doc/source/plugins/b506_yaml_load.rst
+++ b/doc/source/plugins/b506_yaml_load.rst
@@ -1,5 +1,5 @@
----------------
-B506: yaml_load
----------------
+---------
+yaml_load
+---------
 
 .. automodule:: bandit.plugins.yaml_load

--- a/doc/source/plugins/b507_ssh_no_host_key_verification.rst
+++ b/doc/source/plugins/b507_ssh_no_host_key_verification.rst
@@ -1,5 +1,5 @@
-----------------------------------
-B507: ssh_no_host_key_verification
-----------------------------------
+----------------------------
+ssh_no_host_key_verification
+----------------------------
 
 .. automodule:: bandit.plugins.ssh_no_host_key_verification

--- a/doc/source/plugins/b508_snmp_insecure_version.rst
+++ b/doc/source/plugins/b508_snmp_insecure_version.rst
@@ -1,6 +1,6 @@
----------------------------
-B508: snmp_insecure_version
----------------------------
+---------------------
+snmp_insecure_version
+---------------------
 
 .. currentmodule:: bandit.plugins.snmp_security_check
 

--- a/doc/source/plugins/b509_snmp_weak_cryptography.rst
+++ b/doc/source/plugins/b509_snmp_weak_cryptography.rst
@@ -1,6 +1,6 @@
-----------------------------
-B509: snmp_weak_cryptography
-----------------------------
+----------------------
+snmp_weak_cryptography
+----------------------
 
 .. currentmodule:: bandit.plugins.snmp_security_check
 

--- a/doc/source/plugins/b601_paramiko_calls.rst
+++ b/doc/source/plugins/b601_paramiko_calls.rst
@@ -1,5 +1,5 @@
---------------------
-B601: paramiko_calls
---------------------
+--------------
+paramiko_calls
+--------------
 
 .. automodule:: bandit.plugins.injection_paramiko

--- a/doc/source/plugins/b602_subprocess_popen_with_shell_equals_true.rst
+++ b/doc/source/plugins/b602_subprocess_popen_with_shell_equals_true.rst
@@ -1,6 +1,6 @@
----------------------------------------------
-B602: subprocess_popen_with_shell_equals_true
----------------------------------------------
+--------------------------------------
+subprocess_popen_with_shell_equals_true
+--------------------------------------
 
 .. currentmodule:: bandit.plugins.injection_shell
 

--- a/doc/source/plugins/b603_subprocess_without_shell_equals_true.rst
+++ b/doc/source/plugins/b603_subprocess_without_shell_equals_true.rst
@@ -1,6 +1,6 @@
-------------------------------------------
-B603: subprocess_without_shell_equals_true
-------------------------------------------
+------------------------------------
+subprocess_without_shell_equals_true
+------------------------------------
 
 .. currentmodule:: bandit.plugins.injection_shell
 

--- a/doc/source/plugins/b604_any_other_function_with_shell_equals_true.rst
+++ b/doc/source/plugins/b604_any_other_function_with_shell_equals_true.rst
@@ -1,6 +1,6 @@
------------------------------------------------
-B604: any_other_function_with_shell_equals_true
------------------------------------------------
+-----------------------------------------
+any_other_function_with_shell_equals_true
+-----------------------------------------
 
 .. currentmodule:: bandit.plugins.injection_shell
 

--- a/doc/source/plugins/b605_start_process_with_a_shell.rst
+++ b/doc/source/plugins/b605_start_process_with_a_shell.rst
@@ -1,6 +1,6 @@
---------------------------------
-B605: start_process_with_a_shell
---------------------------------
+--------------------------
+start_process_with_a_shell
+--------------------------
 
 .. currentmodule:: bandit.plugins.injection_shell
 

--- a/doc/source/plugins/b606_start_process_with_no_shell.rst
+++ b/doc/source/plugins/b606_start_process_with_no_shell.rst
@@ -1,6 +1,6 @@
----------------------------------
-B606: start_process_with_no_shell
----------------------------------
+---------------------------
+start_process_with_no_shell
+---------------------------
 
 .. currentmodule:: bandit.plugins.injection_shell
 

--- a/doc/source/plugins/b607_start_process_with_partial_path.rst
+++ b/doc/source/plugins/b607_start_process_with_partial_path.rst
@@ -1,6 +1,6 @@
--------------------------------------
-B607: start_process_with_partial_path
--------------------------------------
+-------------------------------
+start_process_with_partial_path
+-------------------------------
 
 .. currentmodule:: bandit.plugins.injection_shell
 

--- a/doc/source/plugins/b608_hardcoded_sql_expressions.rst
+++ b/doc/source/plugins/b608_hardcoded_sql_expressions.rst
@@ -1,5 +1,5 @@
--------------------------------
-B608: hardcoded_sql_expressions
--------------------------------
+-------------------------
+hardcoded_sql_expressions
+-------------------------
 
 .. automodule:: bandit.plugins.injection_sql

--- a/doc/source/plugins/b609_linux_commands_wildcard_injection.rst
+++ b/doc/source/plugins/b609_linux_commands_wildcard_injection.rst
@@ -1,5 +1,5 @@
----------------------------------------
-B609: linux_commands_wildcard_injection
----------------------------------------
+---------------------------------
+linux_commands_wildcard_injection
+---------------------------------
 
 .. automodule:: bandit.plugins.injection_wildcard

--- a/doc/source/plugins/b610_django_extra_used.rst
+++ b/doc/source/plugins/b610_django_extra_used.rst
@@ -1,6 +1,6 @@
------------------------
-B610: django_extra_used
------------------------
+-----------------
+django_extra_used
+-----------------
 
 .. currentmodule:: bandit.plugins.django_sql_injection
 

--- a/doc/source/plugins/b611_django_rawsql_used.rst
+++ b/doc/source/plugins/b611_django_rawsql_used.rst
@@ -1,6 +1,6 @@
-------------------------
-B611: django_rawsql_used
-------------------------
+------------------
+django_rawsql_used
+------------------
 
 .. currentmodule:: bandit.plugins.django_sql_injection
 

--- a/doc/source/plugins/b701_jinja2_autoescape_false.rst
+++ b/doc/source/plugins/b701_jinja2_autoescape_false.rst
@@ -1,5 +1,5 @@
------------------------------
-B701: jinja2_autoescape_false
------------------------------
+-----------------------
+jinja2_autoescape_false
+-----------------------
 
 .. automodule:: bandit.plugins.jinja2_templates

--- a/doc/source/plugins/b702_use_of_mako_templates.rst
+++ b/doc/source/plugins/b702_use_of_mako_templates.rst
@@ -1,5 +1,5 @@
----------------------------
-B702: use_of_mako_templates
----------------------------
+---------------------
+use_of_mako_templates
+---------------------
 
 .. automodule:: bandit.plugins.mako_templates

--- a/doc/source/plugins/b703_django_mark_safe.rst
+++ b/doc/source/plugins/b703_django_mark_safe.rst
@@ -1,6 +1,6 @@
-----------------------
-B703: django_mark_safe
-----------------------
+----------------
+django_mark_safe
+----------------
 
 .. currentmodule:: bandit.plugins.django_xss
 

--- a/doc/source/plugins/index.rst
+++ b/doc/source/plugins/index.rst
@@ -113,8 +113,58 @@ B7xx     XSS
 Complete Test Plugin Listing
 ----------------------------
 
-.. toctree::
-   :maxdepth: 1
-   :glob:
+.. table:: Active Test Plugins
+   :widths: auto
 
-   *
+   ====  ===================================================== ==============  ==============
+   ID    Name                                                  Severity        Confidence
+   ====  ===================================================== ==============  ==============
+   B101  :doc:`b101_assert_used`                               Low             High
+   B102  :doc:`b102_exec_used`                                 Medium          High
+   B103  :doc:`b103_set_bad_file_permissions`                  Medium to High  High
+   B104  :doc:`b104_hardcoded_bind_all_interfaces`             Medium          Medium
+   B105  :doc:`b105_hardcoded_password_string`                 Low             Medium
+   B106  :doc:`b106_hardcoded_password_funcarg`                Low             Medium
+   B107  :doc:`b107_hardcoded_password_default`                Low             Medium
+   B108  :doc:`b108_hardcoded_tmp_directory`                   Medium          Medium
+   B110  :doc:`b110_try_except_pass`                           Low             High
+   B112  :doc:`b112_try_except_continue`                       Low             High
+   B113  :doc:`b113_request_without_timeout`                   Medium          Low
+   B201  :doc:`b201_flask_debug_true`                          High            Medium
+   B324  :doc:`b324_hashlib`                                   Medium to High  High
+   B501  :doc:`b501_request_with_no_cert_validation`           High            High
+   B502  :doc:`b502_ssl_with_bad_version`                      Medium to High  Medium to High
+   B503  :doc:`b503_ssl_with_bad_defaults`                     Medium          Medium
+   B504  :doc:`b504_ssl_with_no_version`                       Low             Medium
+   B505  :doc:`b505_weak_cryptographic_key`                    Medium to High  High
+   B506  :doc:`b506_yaml_load`                                 Medium          High
+   B507  :doc:`b507_ssh_no_host_key_verification`              High            Medium
+   B508  :doc:`b508_snmp_insecure_version`                     Medium          High
+   B509  :doc:`b509_snmp_weak_cryptography`                    Medium          High
+   B601  :doc:`b601_paramiko_calls`                            Medium          Medium
+   B602  :doc:`b602_subprocess_popen_with_shell_equals_true`   Low to High     High
+   B603  :doc:`b603_subprocess_without_shell_equals_true`      Low             High
+   B604  :doc:`b604_any_other_function_with_shell_equals_true` Medium          Low
+   B605  :doc:`b605_start_process_with_a_shell`                Low to High     High
+   B606  :doc:`b606_start_process_with_no_shell`               Low             Medium
+   B607  :doc:`b607_start_process_with_partial_path`           Low             High
+   B608  :doc:`b608_hardcoded_sql_expressions`                 Medium          Low to Medium
+   B609  :doc:`b609_linux_commands_wildcard_injection`         High            Medium
+   B610  :doc:`b610_django_extra_used`                         Medium          Medium
+   B611  :doc:`b611_django_rawsql_used`                        Medium          Medium
+   B612  :doc:`b612_logging_config_insecure_listen`            Medium          High
+   B701  :doc:`b701_jinja2_autoescape_false`                   High            Medium to High
+   B702  :doc:`b702_use_of_mako_templates`                     Medium          High
+   B703  :doc:`b703_django_mark_safe`                          Medium          High
+   ====  ===================================================== ==============  ==============
+
+
+.. table:: Removed Test Plugins
+   :widths: auto
+
+   ====  ===================================================== ==============  ==============
+   ID    Name                                                  Severity        Confidence
+   ====  ===================================================== ==============  ==============
+   B109  :doc:`b109_password_config_option_not_marked_secret`  Medium          Low to Medium
+   B111  :doc:`b111_execute_with_run_as_root_equals_true`      Low             Medium
+   ====  ===================================================== ==============  ==============


### PR DESCRIPTION
Rather than showing the plugins as a simple list, this change
puts them into a table. It also clearly separates active vs.
removed plugins for clarity.

Also discovered as part of this change was that snmp_weak_cryptography
plugin doc file was incorrectly named with the duplicate ID of 508
instead of 509 as it should be.

Signed-off-by: Eric Brown <browne@vmware.com>