### PR TITLE
Remove redundant word Bandit in titles of sections

### DIFF
--- a/doc/source/blacklists/index.rst
+++ b/doc/source/blacklists/index.rst
@@ -1,5 +1,5 @@
-Bandit Blacklist Plugins
-========================
+Blacklist Plugins
+=================
 
 Bandit supports built in functionality to implement blacklisting of imports and
 function calls, this functionality is provided by built in test 'B001'. This

--- a/doc/source/formatters/index.rst
+++ b/doc/source/formatters/index.rst
@@ -1,5 +1,5 @@
-Bandit Report Formatters
-========================
+Report Formatters
+=================
 
 Bandit supports many different formatters to output various security issues in
 python code. These formatters are created as plugins and new ones can be

--- a/doc/source/plugins/index.rst
+++ b/doc/source/plugins/index.rst
@@ -1,5 +1,5 @@
-Bandit Test Plugins
-===================
+Test Plugins
+============
 
 Bandit supports many different tests to detect various security issues in
 python code. These tests are created as plugins and new ones can be created to


### PR DESCRIPTION
We don't need the word "Bandit" prefixed to each of these section
titles:
* Bandit Test Plugins
* Bandit Blacklist Plugins
* Bandit Report Formatters

Signed-off-by: Eric Brown <browne@vmware.com>