### PR TITLE
Adding logging.config.listen() plugin with examples

### DIFF
--- a/bandit/plugins/logging_config_insecure_listen.py
+++ b/bandit/plugins/logging_config_insecure_listen.py
@@ -1,0 +1,50 @@
+# -*- coding:utf-8 -*-
+#
+# Copyright 2014 Hewlett-Packard Development Company, L.P.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+r"""
+====================================================
+B612: Test for insecure use of logging.config.listen
+====================================================
+
+This plugin test checks for the unsafe usage of the
+``logging.config.listen`` function. The logging.config.listen
+function provides the ability to listen for external
+configuration files on a socket server. Because portions of the
+configuration  are passed through eval(), use of this function
+may open its users to a security risk. While the function only
+binds to a socket on localhost, and so does not accept connections
+from remote machines, there are scenarios where untrusted code
+could be run under the account of the process which calls listen().
+
+logging.config.listen provides the ability to verify bytes received
+across the socket with signature verification or encryption/decryption.
+
+:Example:
+    >> Issue: [B612:logging_config_listen] Use of insecure
+    logging.config.listen detected.
+       Severity: Medium   Confidence: High
+       Location: examples/logging_config_insecure_listen.py:3:4
+    2
+    3	t = logging.config.listen(9999)
+
+.. versionadded:: 1.7.4
+
+"""
+
+import bandit
+from bandit.core import test_properties as test
+
+
+@test.checks('Call')
+@test.test_id('B612')
+def logging_config_insecure_listen(context):
+    if context.call_function_name_qual == 'logging.config.listen' \
+            and 'verify' not in context.call_keywords:
+        return bandit.Issue(
+            severity=bandit.MEDIUM,
+            confidence=bandit.HIGH,
+            text="Use of insecure logging.config.listen detected."
+        )

--- a/bandit/plugins/logging_config_insecure_listen.py
+++ b/bandit/plugins/logging_config_insecure_listen.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2022 Rajesh Pangare
 #
 # SPDX-License-Identifier: Apache-2.0
-
 r"""
 ====================================================
 B612: Test for insecure use of logging.config.listen

--- a/bandit/plugins/logging_config_insecure_listen.py
+++ b/bandit/plugins/logging_config_insecure_listen.py
@@ -36,22 +36,21 @@ across the socket with signature verification or encryption/decryption.
 .. versionadded:: 1.7.5
 
 """
-
 import bandit
 from bandit.core import issue
 from bandit.core import test_properties as test
 
 
-@test.checks('Call')
-@test.test_id('B612')
+@test.checks("Call")
+@test.test_id("B612")
 def logging_config_insecure_listen(context):
     if (
-        context.call_function_name_qual == 'logging.config.listen'
-        and 'verify' not in context.call_keywords
+        context.call_function_name_qual == "logging.config.listen"
+        and "verify" not in context.call_keywords
     ):
         return bandit.Issue(
             severity=bandit.MEDIUM,
             confidence=bandit.HIGH,
             cwe=issue.Cwe.CODE_INJECTION,
-            text="Use of insecure logging.config.listen detected."
+            text="Use of insecure logging.config.listen detected.",
         )

--- a/bandit/plugins/logging_config_insecure_listen.py
+++ b/bandit/plugins/logging_config_insecure_listen.py
@@ -1,6 +1,4 @@
-# -*- coding:utf-8 -*-
-#
-# Copyright 2014 Hewlett-Packard Development Company, L.P.
+# Copyright (c) 2022 Rajesh Pangare
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -13,7 +11,7 @@ This plugin test checks for the unsafe usage of the
 ``logging.config.listen`` function. The logging.config.listen
 function provides the ability to listen for external
 configuration files on a socket server. Because portions of the
-configuration  are passed through eval(), use of this function
+configuration are passed through eval(), use of this function
 may open its users to a security risk. While the function only
 binds to a socket on localhost, and so does not accept connections
 from remote machines, there are scenarios where untrusted code
@@ -26,25 +24,33 @@ across the socket with signature verification or encryption/decryption.
     >> Issue: [B612:logging_config_listen] Use of insecure
     logging.config.listen detected.
        Severity: Medium   Confidence: High
+       CWE: CWE-94 (https://cwe.mitre.org/data/definitions/94.html)
        Location: examples/logging_config_insecure_listen.py:3:4
     2
     3	t = logging.config.listen(9999)
 
-.. versionadded:: 1.7.4
+.. seealso::
+
+ - https://docs.python.org/3/library/logging.config.html#logging.config.listen
+
+.. versionadded:: 1.7.5
 
 """
 
 import bandit
-from bandit.core import test_properties as test
+from bandit.core import issue, test_properties as test
 
 
 @test.checks('Call')
 @test.test_id('B612')
 def logging_config_insecure_listen(context):
-    if context.call_function_name_qual == 'logging.config.listen' \
-            and 'verify' not in context.call_keywords:
+    if (
+        context.call_function_name_qual == 'logging.config.listen'
+        and 'verify' not in context.call_keywords
+    ):
         return bandit.Issue(
             severity=bandit.MEDIUM,
             confidence=bandit.HIGH,
+            cwe=issue.Cwe.CODE_INJECTION,
             text="Use of insecure logging.config.listen detected."
         )

--- a/bandit/plugins/logging_config_insecure_listen.py
+++ b/bandit/plugins/logging_config_insecure_listen.py
@@ -38,7 +38,8 @@ across the socket with signature verification or encryption/decryption.
 """
 
 import bandit
-from bandit.core import issue, test_properties as test
+from bandit.core import issue
+from bandit.core import test_properties as test
 
 
 @test.checks('Call')

--- a/doc/source/plugins/b612_logging_config_insecure_listen.rst
+++ b/doc/source/plugins/b612_logging_config_insecure_listen.rst
@@ -1,0 +1,5 @@
+---------------
+B102: exec_used
+---------------
+
+.. automodule:: bandit.plugins.logging_config_insecure_listen

--- a/examples/logging_config_insecure_listen.py
+++ b/examples/logging_config_insecure_listen.py
@@ -1,0 +1,3 @@
+import logging.config
+
+t = logging.config.listen(9999)

--- a/setup.cfg
+++ b/setup.cfg
@@ -137,6 +137,9 @@ bandit.plugins =
     snmp_insecure_version = bandit.plugins.snmp_security_check:snmp_insecure_version_check
     snmp_weak_cryptography = bandit.plugins.snmp_security_check:snmp_crypto_check
 
+    # bandit/plugins/logging_config_insecure_listen.py
+    logging_config_insecure_listen = bandit.plugins.logging_config_insecure_listen:logging_config_insecure_listen
+
 [build_sphinx]
 all_files = 1
 build-dir = doc/build


### PR DESCRIPTION
Hi,
I would like to contribute a plugin based on Python's [security consideration](https://docs.python.org/3/library/logging.config.html#security-considerations) regarding `logging`.

The actual issue (usage of `eval()`) is when `logging.config.fileConfig` is called on an untrusted configuration file. However, it seems very obvious that configuration files are critical for security so will be write-protected to authorised users. The interesting attack vector is possible when an application [exposes socket server](https://docs.python.org/3/library/logging.config.html#logging.config.listen) to listen for configuration file from a network socket that a local attacker can exploit. 

So this plugin checks for usage of `logging.config.listen` without `verify` argument which allows integrity checking or encryption/decryption capability to prevent abuse.

(all tox tests passed)