### PR TITLE
Add dependency review to build job

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -3,6 +3,13 @@ name: Build and Test Bandit
 on: [push, pull_request]
 
 jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v1
   format:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
This change adds a new GitHub Action that can check for a dependency that has known vulnerabilities being introduced via the pull request.

https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement