### PR TITLE
Removal of ghugo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @ericwb @lukehinds @ghugo @sigmavirus24
+*       @ericwb @lukehinds @sigmavirus24


### PR DESCRIPTION
It seems that ghugo is no longer a valid user on GitHub. Also ghugo hasn't been active
in the Bandit community in a long while. Therefore, this change will remove the user.

 Unknown owner on line 1: make sure @ghugo exists and has write access to the repository