### PR TITLE
Remove redundant pip line

### DIFF
--- a/doc/source/start.rst
+++ b/doc/source/start.rst
@@ -16,7 +16,6 @@ Create a virtual environment (optional)::
 Install Bandit::
 
     pip install bandit
-    pip3 install bandit
 
 Run Bandit::
 


### PR DESCRIPTION
The getting started doc informs the user how to install Bandit via pip. However, it gives
instructions to use pip and pip3. Bandit is only supported on Python 3.x now. Also, it's
less common to use pip3 when using convenience modules like pyenv. Therefore, this
change leaves just the pip line.