### PR TITLE
Start testing against Python 3.11

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         python-version: [
-          ["3.7", "37"], ["3.8", "38"], ["3.9", "39"], ["3.10", "310"]
+          ["3.7", "37"], ["3.8", "38"], ["3.9", "39"], ["3.10", "310"], ["3.11.0-alpha.7", "311"]
         ]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Python 3.11 is due for release [in October 2022](https://peps.python.org/pep-0664/).
While this is relatively far away from today, it could still be great to start testing against it, especially for testing that `tomllib` from [PEP 680](https://peps.python.org/pep-0680/) is able to parse configuration correctly.

Python 3.11 alpha 7 is the first pre-release version that includes `tomllib`.