### PR TITLE
Fix an unclosed <b> tag in HTML formatter

### DIFF
--- a/bandit/formatters/html.py
+++ b/bandit/formatters/html.py
@@ -266,7 +266,7 @@ pre {
     <b>Test ID:</b> {test_id}<br>
     <b>Severity: </b>{severity}<br>
     <b>Confidence: </b>{confidence}<br>
-    <b>CWE: <a href="{cwe_link}" target="_blank">CWE-{cwe.id}</a><br>
+    <b>CWE: </b><a href="{cwe_link}" target="_blank">CWE-{cwe.id}</a><br>
     <b>File: </b><a href="{path}" target="_blank">{path}</a><br>
     <b>Line number: </b>{line_number}<br>
     <b>More info: </b><a href="{url}" target="_blank">{url}</a><br>


### PR DESCRIPTION
One line in the `issue_block` template string in `formatters/html.py` is lacking the closing `</b>` tag. As a result, all text after the first occurrence of `CWE:` is bold in the generated HTML report.

Example:
![image](https://user-images.githubusercontent.com/43098013/167285260-78a620ae-0326-4111-8485-578b62de78b8.png)

The same example after applying the fix:
![image](https://user-images.githubusercontent.com/43098013/167285274-18f2eb34-1e29-43ed-980d-91a974fec2fb.png)
