### PR TITLE
'Test plugin listing' in docs incorrectly pointing B612 to plugin ref of B102

### DIFF
--- a/doc/source/plugins/b612_logging_config_insecure_listen.rst
+++ b/doc/source/plugins/b612_logging_config_insecure_listen.rst
@@ -1,5 +1,5 @@
----------------
-B102: exec_used
----------------
+------------------------------------
+B612: logging_config_insecure_listen
+------------------------------------
 
 .. automodule:: bandit.plugins.logging_config_insecure_listen


### PR DESCRIPTION
https://bandit.readthedocs.io/en/latest/plugins/index.html has this typo

<img width="330" alt="Screen Shot 2022-05-08 at 5 14 25 PM" src="https://user-images.githubusercontent.com/4268668/167321750-ab6d7c97-bdb3-47f0-95ba-b5d3257d79a5.png">
