### PR TITLE
Combine coverage data before generating report

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,7 @@ setenv =
 commands =
     coverage erase
     stestr run '{posargs}'
+    coverage combine
     coverage report
 
 [testenv:docs]


### PR DESCRIPTION
This change prevents the `tox -e cover` job from failing with a "No data to report." message. Coverage data collected from parallel test runners must be first combined by running `coverage combine` before the `coverage report` command.