### PR TITLE
Add another bad example of yaml load

### DIFF
--- a/examples/yaml_load.py
+++ b/examples/yaml_load.py
@@ -16,3 +16,5 @@ def test_yaml_load():
 def test_json_load():
     # no issue should be found
     j = json.load("{}")
+
+yaml.load("{}", Loader=yaml.Loader)

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -492,8 +492,8 @@ class FunctionalTests(testtools.TestCase):
     def test_yaml(self):
         """Test for `yaml.load`."""
         expect = {
-            "SEVERITY": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 1, "HIGH": 0},
-            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 1},
+            "SEVERITY": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 2, "HIGH": 0},
+            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 2},
         }
         self.check_example("yaml_load.py", expect)
 


### PR DESCRIPTION
The yaml module supports passing the Loader of choice.
Passing yaml.Loader is considered unsafe. This commit
adds that example and ensures Bandit detects it.

Signed-off-by: Eric Brown <eric_wade_brown@yahoo.com>