### PR TITLE
Add releases link in "Version control integration"

### DIFF
--- a/doc/source/start.rst
+++ b/doc/source/start.rst
@@ -75,7 +75,7 @@ Version control integration
 Use `pre-commit <https://pre-commit.com/>`_. Once you `have it
 installed <https://pre-commit.com/#install>`_, add this to the
 `.pre-commit-config.yaml` in your repository
-(be sure to update `rev` to point to a real git tag/revision!)::
+(be sure to update `rev` to point to a `real git tag/revision <https://github.com/PyCQA/bandit/releases>`_!)::
 
     repos:
     -   repo: https://github.com/PyCQA/bandit


### PR DESCRIPTION
Just a convenience to save someone from finding the repo and tags.

As an alternative, if there's appetite for it, I could rewrite this section. 

- Include a tag in the yaml example.
- Suggest `pre-commit autoupdate --repo "https://github.com/PyCQA/bandit"` which will update the version and install it.
- Remove `pre-commit install suggestion` 