### PR TITLE
Update version of dependency-review-action

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v1
+        uses: actions/dependency-review-action@v2


### PR DESCRIPTION
New major release of this action:
https://github.com/actions/dependency-review-action/releases/tag/v2.0.0