### PR TITLE
Avoid redundant message if debug on

### DIFF
--- a/bandit/core/manager.py
+++ b/bandit/core/manager.py
@@ -331,12 +331,13 @@ class BanditManager:
             new_files_list.remove(fname)
         except Exception as e:
             LOG.error(
-                "Exception occurred when executing tests against "
-                '%s. Run "bandit --debug %s" to see the full '
-                "traceback.",
+                "Exception occurred when executing tests against %s.",
                 fname,
                 fname,
             )
+            if not LOG.isEnabledFor(logging.DEBUG):
+                LOG.error('Run "bandit --debug %s" to see the full traceback.')
+
             self.skipped.append((fname, "exception while scanning file"))
             new_files_list.remove(fname)
             LOG.debug("  Exception string: %s", e)


### PR DESCRIPTION
Only print the message to use "--debug" if debug logging not already
turned on.

Closes #883

Signed-off-by: Eric Brown <eric_wade_brown@yahoo.com>