### PR TITLE
Remove invalid checking on hashlib

### DIFF
--- a/examples/hashlib_new_insecure_functions.py
+++ b/examples/hashlib_new_insecure_functions.py
@@ -2,21 +2,19 @@ import hashlib
 
 hashlib.new('md5')
 
-hashlib.new('md4', 'test')
+hashlib.new('md4', b'test')
 
-hashlib.new(name='md5', string='test')
+hashlib.new(name='md5', data=b'test')
 
-hashlib.new('MD4', string='test')
-
-hashlib.new(string='test', name='MD5')
+hashlib.new('MD4', data=b'test')
 
 hashlib.new('sha1')
 
-hashlib.new(string='test', name='SHA1')
+hashlib.new('sha1', data=b'test')
 
-hashlib.new('sha', string='test')
+hashlib.new('sha', data=b'test')
 
-hashlib.new(name='SHA', string='test')
+hashlib.new(name='SHA', data=b'test')
 
 # usedforsecurity arg only availabe in Python 3.9+
 hashlib.new('sha1', usedforsecurity=True)

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -828,13 +828,13 @@ class FunctionalTests(testtools.TestCase):
                     "UNDEFINED": 0,
                     "LOW": 0,
                     "MEDIUM": 0,
-                    "HIGH": 10,
+                    "HIGH": 9,
                 },
                 "CONFIDENCE": {
                     "UNDEFINED": 0,
                     "LOW": 0,
                     "MEDIUM": 0,
-                    "HIGH": 10,
+                    "HIGH": 9,
                 },
             }
         else:
@@ -842,14 +842,14 @@ class FunctionalTests(testtools.TestCase):
                 "SEVERITY": {
                     "UNDEFINED": 0,
                     "LOW": 0,
-                    "MEDIUM": 11,
+                    "MEDIUM": 10,
                     "HIGH": 0,
                 },
                 "CONFIDENCE": {
                     "UNDEFINED": 0,
                     "LOW": 0,
                     "MEDIUM": 0,
-                    "HIGH": 11,
+                    "HIGH": 10,
                 },
             }
         self.check_example("hashlib_new_insecure_functions.py", expect)


### PR DESCRIPTION
* hashlib does not support name as the kwargs argument
* 'string' is not a keyword of kwargs

Fixes #865

Signed-off-by: Eric Brown <eric_wade_brown@yahoo.com>