### PR TITLE
Avoid calls to ast in plugins

### DIFF
--- a/bandit/core/blacklisting.py
+++ b/bandit/core/blacklisting.py
@@ -2,10 +2,10 @@
 # Copyright 2016 Hewlett-Packard Development Company, L.P.
 #
 # SPDX-License-Identifier: Apache-2.0
-import ast
 import fnmatch
 
 from bandit.core import issue
+from bandit.core import utils
 
 
 def report_issue(check, name):
@@ -34,9 +34,9 @@ def blacklist(context, config):
 
     if node_type == "Call":
         func = context.node.func
-        if isinstance(func, ast.Name) and func.id == "__import__":
+        if utils.is_instance(func, "Name") and func.id == "__import__":
             if len(context.node.args):
-                if isinstance(context.node.args[0], ast.Str):
+                if utils.is_instance(context.node.args[0], "Str"):
                     name = context.node.args[0].s
                 else:
                     # TODO(??): import through a variable, need symbol tab

--- a/bandit/core/context.py
+++ b/bandit/core/context.py
@@ -2,8 +2,6 @@
 # Copyright 2014 Hewlett-Packard Development Company, L.P.
 #
 # SPDX-License-Identifier: Apache-2.0
-import ast
-
 from bandit.core import utils
 
 
@@ -178,44 +176,44 @@ class Context:
         :param literal: The AST literal to convert
         :return: The value of the AST literal
         """
-        if isinstance(literal, ast.Num):
+        if utils.is_instance(literal, "Num"):
             literal_value = literal.n
 
-        elif isinstance(literal, ast.Str):
+        elif utils.is_instance(literal, "Str"):
             literal_value = literal.s
 
-        elif isinstance(literal, ast.List):
+        elif utils.is_instance(literal, "List"):
             return_list = list()
             for li in literal.elts:
                 return_list.append(self._get_literal_value(li))
             literal_value = return_list
 
-        elif isinstance(literal, ast.Tuple):
+        elif utils.is_instance(literal, "Tuple"):
             return_tuple = tuple()
             for ti in literal.elts:
                 return_tuple = return_tuple + (self._get_literal_value(ti),)
             literal_value = return_tuple
 
-        elif isinstance(literal, ast.Set):
+        elif utils.is_instance(literal, "Set"):
             return_set = set()
             for si in literal.elts:
                 return_set.add(self._get_literal_value(si))
             literal_value = return_set
 
-        elif isinstance(literal, ast.Dict):
+        elif utils.is_instance(literal, "Dict"):
             literal_value = dict(zip(literal.keys, literal.values))
 
-        elif isinstance(literal, ast.Ellipsis):
+        elif utils.is_instance(literal, "Ellipsis"):
             # what do we want to do with this?
             literal_value = None
 
-        elif isinstance(literal, ast.Name):
+        elif utils.is_instance(literal, "Name"):
             literal_value = literal.id
 
-        elif isinstance(literal, ast.NameConstant):
+        elif utils.is_instance(literal, "NameConstant"):
             literal_value = str(literal.value)
 
-        elif isinstance(literal, ast.Bytes):
+        elif utils.is_instance(literal, "Bytes"):
             literal_value = literal.s
 
         else:

--- a/bandit/core/utils.py
+++ b/bandit/core/utils.py
@@ -6,6 +6,7 @@ import ast
 import logging
 import os.path
 import sys
+from operator import attrgetter
 
 try:
     import configparser
@@ -370,3 +371,13 @@ def check_ast_node(name):
         pass
 
     raise TypeError("Error: %s is not a valid node type in AST" % name)
+
+
+def is_instance(node, type_name):
+    "Check if the given node is an instance AST type."
+    if isinstance(type_name, tuple):
+        f = attrgetter(*type_name)
+        return isinstance(node, f(ast))
+    else:
+        node_type = getattr(ast, type_name)
+        return isinstance(node, node_type)

--- a/bandit/plugins/django_sql_injection.py
+++ b/bandit/plugins/django_sql_injection.py
@@ -2,17 +2,16 @@
 # Copyright (C) 2018 [Victor Torre](https://github.com/ehooo)
 #
 # SPDX-License-Identifier: Apache-2.0
-import ast
-
 import bandit
 from bandit.core import issue
 from bandit.core import test_properties as test
+from bandit.core import utils
 
 
 def keywords2dict(keywords):
     kwargs = {}
     for node in keywords:
-        if isinstance(node, ast.keyword):
+        if utils.is_instance(node, "keyword"):
             kwargs[node.arg] = node.value
     return kwargs
 
@@ -66,23 +65,23 @@ def django_extra_used(context):
         insecure = False
         for key in ["where", "tables"]:
             if key in kwargs:
-                if isinstance(kwargs[key], ast.List):
+                if utils.is_instance(kwargs[key], "List"):
                     for val in kwargs[key].elts:
-                        if not isinstance(val, ast.Str):
+                        if not utils.is_instance(val, "Str"):
                             insecure = True
                             break
                 else:
                     insecure = True
                     break
         if not insecure and "select" in kwargs:
-            if isinstance(kwargs["select"], ast.Dict):
+            if utils.is_instance(kwargs["select"], "Dict"):
                 for k in kwargs["select"].keys:
-                    if not isinstance(k, ast.Str):
+                    if not utils.is_instance(k, "Str"):
                         insecure = True
                         break
                 if not insecure:
                     for v in kwargs["select"].values:
-                        if not isinstance(v, ast.Str):
+                        if not utils.is_instance(v, "Str"):
                             insecure = True
                             break
             else:
@@ -130,7 +129,7 @@ def django_rawsql_used(context):
     if context.is_module_imported_like("django.db.models"):
         if context.call_function_name == "RawSQL":
             sql = context.node.args[0]
-            if not isinstance(sql, ast.Str):
+            if not utils.is_instance(sql, "Str"):
                 return bandit.Issue(
                     severity=bandit.MEDIUM,
                     confidence=bandit.MEDIUM,

--- a/bandit/plugins/injection_sql.py
+++ b/bandit/plugins/injection_sql.py
@@ -53,13 +53,13 @@ If so, a MEDIUM issue is reported. For example:
     CWE information added
 
 """  # noqa: E501
-import ast
 import re
 
 import bandit
 from bandit.core import issue
 from bandit.core import test_properties as test
 from bandit.core import utils
+
 
 SIMPLE_SQL_RE = re.compile(
     r"(select\s.*from\s|"
@@ -78,24 +78,24 @@ def _evaluate_ast(node):
     wrapper = None
     statement = ""
 
-    if isinstance(node._bandit_parent, ast.BinOp):
+    if utils.is_instance(node._bandit_parent, "BinOp"):
         out = utils.concat_string(node, node._bandit_parent)
         wrapper = out[0]._bandit_parent
         statement = out[1]
     elif (
-        isinstance(node._bandit_parent, ast.Attribute)
+        utils.is_instance(node._bandit_parent, "Attribute")
         and node._bandit_parent.attr == "format"
     ):
         statement = node.s
         # Hierarchy for "".format() is Wrapper -> Call -> Attribute -> Str
         wrapper = node._bandit_parent._bandit_parent._bandit_parent
-    elif hasattr(ast, "JoinedStr") and isinstance(
-        node._bandit_parent, ast.JoinedStr
+    elif utils.check_ast_node("JoinedStr") and utils.is_instance(
+        node._bandit_parent, "JoinedStr"
     ):
         statement = node.s
         wrapper = node._bandit_parent._bandit_parent
 
-    if isinstance(wrapper, ast.Call):  # wrapped in "execute" call?
+    if utils.is_instance(wrapper, "Call"):  # wrapped in "execute" call?
         names = ["execute", "executemany"]
         name = utils.get_called_name(wrapper)
         return (name in names, statement)

--- a/bandit/plugins/jinja2_templates.py
+++ b/bandit/plugins/jinja2_templates.py
@@ -68,6 +68,7 @@ import ast
 import bandit
 from bandit.core import issue
 from bandit.core import test_properties as test
+from bandit.core import utils
 
 
 @test.checks("Call")
@@ -79,7 +80,7 @@ def jinja2_autoescape_false(context):
         func = qualname_list[-1]
         if "jinja2" in qualname_list and func == "Environment":
             for node in ast.walk(context.node):
-                if isinstance(node, ast.keyword):
+                if utils.is_instance(node, "keyword"):
                     # definite autoescape = False
                     if getattr(node, "arg", None) == "autoescape" and (
                         getattr(node.value, "id", None) == "False"
@@ -105,7 +106,7 @@ def jinja2_autoescape_false(context):
                             return
                         # Check if select_autoescape function is used.
                         elif (
-                            isinstance(value, ast.Call)
+                            utils.is_instance(value, "Call")
                             and getattr(value.func, "id", None)
                             == "select_autoescape"
                         ):

--- a/bandit/plugins/try_except_continue.py
+++ b/bandit/plugins/try_except_continue.py
@@ -74,11 +74,10 @@ following would not generate a warning if the configuration option
     CWE information added
 
 """
-import ast
-
 import bandit
 from bandit.core import issue
 from bandit.core import test_properties as test
+from bandit.core import utils
 
 
 def gen_config(name):
@@ -99,7 +98,7 @@ def try_except_continue(context, config):
         ):
             return
 
-        if isinstance(node.body[0], ast.Continue):
+        if utils.is_instance(node.body[0], "Continue"):
             return bandit.Issue(
                 severity=bandit.LOW,
                 confidence=bandit.HIGH,

--- a/bandit/plugins/try_except_pass.py
+++ b/bandit/plugins/try_except_pass.py
@@ -72,11 +72,10 @@ would not generate a warning if the configuration option
     CWE information added
 
 """
-import ast
-
 import bandit
 from bandit.core import issue
 from bandit.core import test_properties as test
+from bandit.core import utils
 
 
 def gen_config(name):
@@ -97,7 +96,7 @@ def try_except_pass(context, config):
         ):
             return
 
-        if isinstance(node.body[0], ast.Pass):
+        if utils.is_instance(node.body[0], "Pass"):
             return bandit.Issue(
                 severity=bandit.LOW,
                 confidence=bandit.HIGH,


### PR DESCRIPTION
If one day we do wish to have the capability to swap the builtin
Python ast for another parser, it's best to abstract any direct
calls to the ast parser in plugins.

This change addresses calls from plugins and other functions to
isinstance with ast node types as arguments. Further work is needed
for other ast calls in subsequent patches.

Related to #894

Signed-off-by: Eric Brown <eric_wade_brown@yahoo.com>