### PR TITLE
Add some missing curve types

### DIFF
--- a/bandit/plugins/weak_cryptographic_key.py
+++ b/bandit/plugins/weak_cryptographic_key.py
@@ -111,6 +111,22 @@ def _weak_crypto_key_size_cryptography_io(context, config):
         return _classify_key_size(config, key_type, key_size)
     elif key_type == "EC":
         curve_key_sizes = {
+            "SECT571K1": 571,
+            "SECT571R1": 570,
+            "SECP521R1": 521,
+            "BrainpoolP512R1": 512,
+            "SECT409K1": 409,
+            "SECT409R1": 409,
+            "BrainpoolP384R1": 384,
+            "SECP384R1": 384,
+            "SECT283K1": 283,
+            "SECT283R1": 283,
+            "BrainpoolP256R1": 256,
+            "SECP256K1": 256,
+            "SECP256R1": 256,
+            "SECT233K1": 233,
+            "SECT233R1": 233,
+            "SECP224R1": 224,
             "SECP192R1": 192,
             "SECT163K1": 163,
             "SECT163R2": 163,


### PR DESCRIPTION
The weak_cryptographic_key plugin is missing some various
elliptical curve types.

Signed-off-by: Eric Brown <eric_wade_brown@yahoo.com>