### PR TITLE
Fix reading the number argument from config file

### DIFF
--- a/bandit/cli/main.py
+++ b/bandit/cli/main.py
@@ -512,8 +512,7 @@ def main():
         args.context_lines = _log_option_source(
             parser.get_default("context_lines"),
             args.context_lines,
-            (None if ini_options.get("number") is None
-                else int(ini_options.get("number"))),
+            int(ini_options.get("number") or 0) or None,
             "max code lines output for issue",
         )
 

--- a/bandit/cli/main.py
+++ b/bandit/cli/main.py
@@ -512,7 +512,8 @@ def main():
         args.context_lines = _log_option_source(
             parser.get_default("context_lines"),
             args.context_lines,
-            ini_options.get("number"),
+            (None if ini_options.get("number") is None
+                else int(ini_options.get("number"))),
             "max code lines output for issue",
         )
 


### PR DESCRIPTION
When passing the "number" option from the INI file we did
not take into account to store its value as an integer
(when that value is not None).

Resolves: #922