### PR TITLE
Fixup some invalid pickle testing

### DIFF
--- a/bandit/blacklists/calls.py
+++ b/bandit/blacklists/calls.py
@@ -24,9 +24,6 @@ deserialize untrusted data, possible security issue.
 | B301 | pickle              | - pickle.loads                     | Medium    |
 |      |                     | - pickle.load                      |           |
 |      |                     | - pickle.Unpickler                 |           |
-|      |                     | - cPickle.loads                    |           |
-|      |                     | - cPickle.load                     |           |
-|      |                     | - cPickle.Unpickler                |           |
 |      |                     | - dill.loads                       |           |
 |      |                     | - dill.load                        |           |
 |      |                     | - dill.Unpickler                   |           |
@@ -347,9 +344,6 @@ def gen_blacklist():
                 "pickle.loads",
                 "pickle.load",
                 "pickle.Unpickler",
-                "cPickle.loads",
-                "cPickle.load",
-                "cPickle.Unpickler",
                 "dill.loads",
                 "dill.load",
                 "dill.Unpickler",

--- a/examples/dill.py
+++ b/examples/dill.py
@@ -1,14 +1,14 @@
 import dill
-import StringIO
+import io
 
 # dill
 pick = dill.dumps({'a': 'b', 'c': 'd'})
 print(dill.loads(pick))
 
-file_obj = StringIO.StringIO()
+file_obj = io.BytesIO()
 dill.dump([1, 2, '3'], file_obj)
 file_obj.seek(0)
 print(dill.load(file_obj))
 
 file_obj.seek(0)
-print(dill.Undillr(file_obj).load())
+print(dill.Unpickler(file_obj).load())

--- a/examples/pickle_deserialize.py
+++ b/examples/pickle_deserialize.py
@@ -1,29 +1,15 @@
-import cPickle
+import io
 import pickle
-import StringIO
 
 
 # pickle
 pick = pickle.dumps({'a': 'b', 'c': 'd'})
 print(pickle.loads(pick))
 
-file_obj = StringIO.StringIO()
+file_obj = io.BytesIO()
 pickle.dump([1, 2, '3'], file_obj)
 file_obj.seek(0)
 print(pickle.load(file_obj))
 
 file_obj.seek(0)
 print(pickle.Unpickler(file_obj).load())
-
-# cPickle
-serialized = cPickle.dumps({(): []})
-print(cPickle.loads(serialized))
-
-file_obj = StringIO.StringIO()
-cPickle.dump((1,), file_obj)
-file_obj.seek(0)
-print(cPickle.load(file_obj))
-
-file_obj.seek(0)
-print(cPickle.Unpickler(file_obj).load())
-

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -348,16 +348,16 @@ class FunctionalTests(testtools.TestCase):
     def test_pickle(self):
         """Test for the `pickle` module."""
         expect = {
-            "SEVERITY": {"UNDEFINED": 0, "LOW": 2, "MEDIUM": 6, "HIGH": 0},
-            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 8},
+            "SEVERITY": {"UNDEFINED": 0, "LOW": 1, "MEDIUM": 3, "HIGH": 0},
+            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 4},
         }
         self.check_example("pickle_deserialize.py", expect)
 
     def test_dill(self):
         """Test for the `dill` module."""
         expect = {
-            "SEVERITY": {"UNDEFINED": 0, "LOW": 1, "MEDIUM": 2, "HIGH": 0},
-            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 3},
+            "SEVERITY": {"UNDEFINED": 0, "LOW": 1, "MEDIUM": 3, "HIGH": 0},
+            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 4},
         }
         self.check_example("dill.py", expect)
 


### PR DESCRIPTION
* cPickle doesn't exist in Python 3+, therefore we can drop
* examples/pickle_deserialize.py uses StringIO.StringIO which was
  replaced with io.StringIO. However, these calls expect bytes, not str
* Similarly examples/dill.py using StringIO to be replaced with BytesIO.
  It was also using an instance of an non-existant class name of Undillr
  and not Unpickler.

Signed-off-by: Eric Brown <eric_wade_brown@yahoo.com>