### PR TITLE
Docs for request without timeout has dead link

### DIFF
--- a/bandit/plugins/request_without_timeout.py
+++ b/bandit/plugins/request_without_timeout.py
@@ -38,7 +38,7 @@ Bandit will return a MEDIUM severity error.
 
 .. seealso::
 
- - https://2.python-requests.org/en/master/user/quickstart/#timeouts
+ - https://requests.readthedocs.io/en/latest/user/advanced/#timeouts
 
 .. versionadded:: 1.7.5
 


### PR DESCRIPTION
The see also section refers to an invalid URL. This change updates
with the latest known reference.

Signed-off-by: Eric Brown <eric_wade_brown@yahoo.com>