### PR TITLE
Fix a false positive condition yaml_load

### DIFF
--- a/bandit/core/context.py
+++ b/bandit/core/context.py
@@ -276,9 +276,8 @@ class Context:
         """
         max_args = self.call_args_count
         if max_args and position_num < max_args:
-            return self._get_literal_value(
-                self._context["call"].args[position_num]
-            )
+            arg = self._context["call"].args[position_num]
+            return getattr(arg, "attr", None) or self._get_literal_value(arg)
         else:
             return None
 

--- a/bandit/plugins/yaml_load.py
+++ b/bandit/plugins/yaml_load.py
@@ -62,6 +62,8 @@ def yaml_load(context):
             func == "load",
             not context.check_call_arg_value("Loader", "SafeLoader"),
             not context.check_call_arg_value("Loader", "CSafeLoader"),
+            not context.get_call_arg_at_position(1) == "SafeLoader",
+            not context.get_call_arg_at_position(1) == "CSafeLoader",
         ]
     ):
         return bandit.Issue(

--- a/examples/yaml_load.py
+++ b/examples/yaml_load.py
@@ -1,5 +1,7 @@
 import json
 import yaml
+from yaml import CSafeLoader
+from yaml import SafeLoader
 
 
 def test_yaml_load():
@@ -18,3 +20,9 @@ def test_json_load():
     j = json.load("{}")
 
 yaml.load("{}", Loader=yaml.Loader)
+
+# no issue should be found
+yaml.load("{}", SafeLoader)
+yaml.load("{}", yaml.SafeLoader)
+yaml.load("{}", CSafeLoader)
+yaml.load("{}", yaml.CSafeLoader)


### PR DESCRIPTION
The yaml.load() function has a second argument that is typically
passed as a kwarg. However, someone could pass as a positional
argument as well. In such a case, Bandit would flag code passing
a SafeLoader even though that is validly secure.

The fix involves looking at the positional args. However, the
convenience function to do so also had no handling of ast.Attribute
as args. So get_call_arg_at_position() was modified to function much
like call_args().

Closes #546

Signed-off-by: Eric Brown <eric_wade_brown@yahoo.com>