### PR TITLE
Check for deprecated TLS 1.1

### DIFF
--- a/bandit/plugins/insecure_ssl_tls.py
+++ b/bandit/plugins/insecure_ssl_tls.py
@@ -22,6 +22,8 @@ def gen_config(name):
                 "PROTOCOL_TLSv1",  # strict option
                 "SSLv3_METHOD",  # strict option
                 "TLSv1_METHOD",
+                "PROTOCOL_TLSv1_1",
+                "TLSv1_1_METHOD",
             ]
         }  # strict option
 
@@ -105,6 +107,9 @@ def ssl_with_bad_version(context, config):
 
     .. versionchanged:: 1.7.3
         CWE information added
+
+    .. versionchanged:: 1.7.5
+        Added TLS 1.1
 
     """
     bad_ssl_versions = get_bad_proto_versions(config)
@@ -195,6 +200,9 @@ def ssl_with_bad_defaults(context, config):
 
     .. versionchanged:: 1.7.3
         CWE information added
+
+    .. versionchanged:: 1.7.5
+        Added TLS 1.1
 
     """
 

--- a/examples/ssl-insecure-version.py
+++ b/examples/ssl-insecure-version.py
@@ -20,6 +20,13 @@ herp_derp(ssl_version=ssl.PROTOCOL_TLSv1)
 herp_derp(method=SSL.SSLv3_METHOD)
 herp_derp(method=SSL.TLSv1_METHOD)
 
+ssl.wrap_socket(ssl_version=ssl.PROTOCOL_TLSv1_1)
+SSL.Context(method=SSL.TLSv1_1_METHOD)
+
+herp_derp(ssl_version=ssl.PROTOCOL_TLSv1_1)
+herp_derp(method=SSL.TLSv1_1_METHOD)
+
+
 ssl.wrap_socket()
 
 def open_ssl_socket(version=ssl.PROTOCOL_SSLv2):
@@ -31,6 +38,9 @@ def open_ssl_socket(version=SSL.SSLv2_METHOD):
 def open_ssl_socket(version=SSL.SSLv23_METHOD):
     pass
 
-# this one will pass ok
 def open_ssl_socket(version=SSL.TLSv1_1_METHOD):
+    pass
+
+# this one will pass ok
+def open_ssl_socket(version=SSL.TLSv1_2_METHOD):
     pass

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -454,12 +454,8 @@ class FunctionalTests(testtools.TestCase):
     def test_ssl_insecure_version(self):
         """Test for insecure SSL protocol versions."""
         expect = {
-            "SEVERITY": {"LOW": 1, "MEDIUM": 10, "HIGH": 7},
-            "CONFIDENCE": {"LOW": 0, "MEDIUM": 11, "HIGH": 7},
-        }
-        expect = {
-            "SEVERITY": {"UNDEFINED": 0, "LOW": 1, "MEDIUM": 10, "HIGH": 7},
-            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 11, "HIGH": 7},
+            "SEVERITY": {"UNDEFINED": 0, "LOW": 1, "MEDIUM": 13, "HIGH": 9},
+            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 14, "HIGH": 9},
         }
         self.check_example("ssl-insecure-version.py", expect)
 


### PR DESCRIPTION
The IETF officially deprecated TLS 1.1 in March 2021. As such,
Bandit should now check for and warn of its use.

https://datatracker.ietf.org/doc/rfc8996/

Signed-off-by: Eric Brown <eric_wade_brown@yahoo.com>