### PR TITLE
Fix json and yaml formatters to respect num lines

### DIFF
--- a/bandit/core/issue.py
+++ b/bandit/core/issue.py
@@ -196,7 +196,7 @@ class Issue:
             lines.append(tmplt % (line, text))
         return "".join(lines)
 
-    def as_dict(self, with_code=True):
+    def as_dict(self, with_code=True, max_lines=3):
         """Convert the issue to a dict of values for outputting."""
         out = {
             "filename": self.fname,
@@ -213,7 +213,7 @@ class Issue:
         }
 
         if with_code:
-            out["code"] = self.get_code()
+            out["code"] = self.get_code(max_lines=max_lines)
         return out
 
     def from_dict(self, data, with_code=True):

--- a/bandit/formatters/json.py
+++ b/bandit/formatters/json.py
@@ -111,14 +111,16 @@ def report(manager, fileobj, sev_level, conf_level, lines=-1):
     if baseline:
         collector = []
         for r in results:
-            d = r.as_dict()
+            d = r.as_dict(max_lines=lines)
             d["more_info"] = docs_utils.get_url(d["test_id"])
             if len(results[r]) > 1:
-                d["candidates"] = [c.as_dict() for c in results[r]]
+                d["candidates"] = [
+                    c.as_dict(max_lines=lines) for c in results[r]
+                ]
             collector.append(d)
 
     else:
-        collector = [r.as_dict() for r in results]
+        collector = [r.as_dict(max_lines=lines) for r in results]
         for elem in collector:
             elem["more_info"] = docs_utils.get_url(elem["test_id"])
 

--- a/bandit/formatters/yaml.py
+++ b/bandit/formatters/yaml.py
@@ -91,7 +91,7 @@ def report(manager, fileobj, sev_level, conf_level, lines=-1):
         sev_level=sev_level, conf_level=conf_level
     )
 
-    collector = [r.as_dict() for r in results]
+    collector = [r.as_dict(max_lines=lines) for r in results]
     for elem in collector:
         elem["more_info"] = docs_utils.get_url(elem["test_id"])
 


### PR DESCRIPTION
The json and yaml formatters were not outputting the lines of
content according to the user's selection.

This is a result of issue:as_dict() function that does not pass
through the max_lines argument to get_code. As a result, it
would always return the default of 3.

This change now optionally passes through desired lines of content.

Fixes #604

Signed-off-by: Eric Brown <eric_wade_brown@yahoo.com>