### PR TITLE
weak_cryptographic_key assumes positional arg

### DIFF
--- a/bandit/plugins/weak_cryptographic_key.py
+++ b/bandit/plugins/weak_cryptographic_key.py
@@ -131,9 +131,9 @@ def _weak_crypto_key_size_cryptography_io(context, config):
             "SECT163K1": 163,
             "SECT163R2": 163,
         }
-        curve = (
-            context.get_call_arg_value("curve")
-            or context.call_args[arg_position[key_type]]
+        curve = context.get_call_arg_value("curve") or (
+            len(context.call_args) > arg_position[key_type]
+            and context.call_args[arg_position[key_type]]
         )
         key_size = curve_key_sizes[curve] if curve in curve_key_sizes else 224
         return _classify_key_size(config, key_type, key_size)

--- a/examples/weak_cryptographic_key_sizes.py
+++ b/examples/weak_cryptographic_key_sizes.py
@@ -64,3 +64,9 @@ pycryptodomex_rsa.generate(512)
 rsa.generate_private_key(public_exponent=65537,
                          key_size=some_key_size,
                          backend=backends.default_backend())
+
+# Can't reliably know which curve was passed, in some cases like below
+ec.generate_private_key(
+    curve=curves[self.curve]['create'](self.size),
+    backend=backends.default_backend()
+)


### PR DESCRIPTION
The weak_cryptographic_key assumes a positional arg when it doesn't
find a value for the keyword arg. The issue is that sometimes the
keyword arg is a ast.Call or other undeterminate values. And as
a result throws a Traceback.

This change will make the plugin a little more robust so it doesn't
throw the Traceback. It won't be able determine the value of the
curve in this case, but can ignore it.

Fixes #545

Signed-off-by: Eric Brown <eric_wade_brown@yahoo.com>