### PR TITLE
Fix AttributeError on detect of tuple assign condition

### DIFF
--- a/bandit/plugins/django_xss.py
+++ b/bandit/plugins/django_xss.py
@@ -70,7 +70,9 @@ class DeepAssignation:
             if isinstance(target, ast.Name):
                 if target.id == self.var_name.id:
                     assigned = node.value
-            elif isinstance(target, ast.Tuple):
+            elif isinstance(target, ast.Tuple) and isinstance(
+                node.value, ast.Tuple
+            ):
                 pos = 0
                 for name in target.elts:
                     if name.id == self.var_name.id:

--- a/examples/mark_safe_insecure.py
+++ b/examples/mark_safe_insecure.py
@@ -157,3 +157,11 @@ def test_insecure_with_assign(str_arg=None):
     if not str_arg:
         str_arg = 'could be insecure'
     safestring.mark_safe(str_arg)
+
+def test_insecure_tuple_assign():
+    HTML_CHOICES = (
+        (_('Donate'), 'https://example.org/donate/'),
+        (_('More info'), 'https://example.org/'),
+    )
+    text, url = choice(HTML_CHOICES)
+    safestring.mark_safe('<a href="{0}">{1}</a>'.format(url, text))

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -547,8 +547,8 @@ class FunctionalTests(testtools.TestCase):
     def test_django_xss_insecure(self):
         """Test for Django XSS via django.utils.safestring"""
         expect = {
-            "SEVERITY": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 28, "HIGH": 0},
-            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 28},
+            "SEVERITY": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 29, "HIGH": 0},
+            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 29},
         }
         self.b_mgr.b_ts = b_test_set.BanditTestSet(
             config=self.b_mgr.b_conf, profile={"exclude": ["B308"]}


### PR DESCRIPTION
In a specific example where a tuple is assigned to a call
such as a choice of options, Bandit throws a traceback due
to an assumption the assign is to a value of another tuple
instead of a call.

This change will avoid the traceback, but not necessarily help
in detection of an XSS in this example.

Fixes #520

Signed-off-by: Eric Brown <eric_wade_brown@yahoo.com>