### PR TITLE
Remove python 2 reference in docs

### DIFF
--- a/bandit/plugins/exec.py
+++ b/bandit/plugins/exec.py
@@ -23,7 +23,6 @@ Python docs succinctly describe why the use of `exec` is risky.
 
 .. seealso::
 
- - https://docs.python.org/2/reference/simple_stmts.html#exec
  - https://docs.python.org/3/library/functions.html#exec
  - https://www.python.org/dev/peps/pep-0551/#background
  - https://www.python.org/dev/peps/pep-0578/#suggested-audit-hook-locations


### PR DESCRIPTION
Bandit no longer supports Python 2, so there is no need
for a plugin to reference exec() in the Py2 docs.