### PR TITLE
Pass correct number of arguments to match the `%s` placeholders.

### DIFF
--- a/bandit/core/manager.py
+++ b/bandit/core/manager.py
@@ -331,12 +331,12 @@ class BanditManager:
             new_files_list.remove(fname)
         except Exception as e:
             LOG.error(
-                "Exception occurred when executing tests against %s.",
-                fname,
-                fname,
+                "Exception occurred when executing tests against %s.", fname
             )
             if not LOG.isEnabledFor(logging.DEBUG):
-                LOG.error('Run "bandit --debug %s" to see the full traceback.')
+                LOG.error(
+                    'Run "bandit --debug %s" to see the full traceback.', fname
+                )
 
             self.skipped.append((fname, "exception while scanning file"))
             new_files_list.remove(fname)


### PR DESCRIPTION
Pull request #913 didn't adjust the arguments to be interpolated in the logging message (arguments do not match the `%s` placeholders). As a result, there is an unhandled TypeError and failed string interpolation. This change fixes that.

Before:

![image](https://user-images.githubusercontent.com/43098013/178967332-6202aced-192b-46e8-a6ba-7ba11a4ec9c7.png)

After:

![image](https://user-images.githubusercontent.com/43098013/178967430-67da4259-02e8-422c-84fc-2ab843b248ac.png)
