### PR TITLE
Add `random.Random` to B311 checks

### DIFF
--- a/bandit/blacklists/calls.py
+++ b/bandit/blacklists/calls.py
@@ -189,7 +189,8 @@ purposes.
 +------+---------------------+------------------------------------+-----------+
 | ID   |  Name               |  Calls                             |  Severity |
 +======+=====================+====================================+===========+
-| B311 | random              | - random.random                    | Low       |
+| B311 | random              | - random.Random                    | Low       |
+|      |                     | - random.random                    |           |
 |      |                     | - random.randrange                 |           |
 |      |                     | - random.randint                   |           |
 |      |                     | - random.choice                    |           |
@@ -519,6 +520,7 @@ def gen_blacklist():
             "B311",
             issue.Cwe.INSUFFICIENT_RANDOM_VALUES,
             [
+                "random.Random",
                 "random.random",
                 "random.randrange",
                 "random.randint",

--- a/examples/random_module.py
+++ b/examples/random_module.py
@@ -2,6 +2,7 @@ import random
 import os
 import somelib
 
+bad = random.Random()
 bad = random.random()
 bad = random.randrange()
 bad = random.randint()

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -396,8 +396,8 @@ class FunctionalTests(testtools.TestCase):
     def test_random_module(self):
         """Test for the `random` module."""
         expect = {
-            "SEVERITY": {"UNDEFINED": 0, "LOW": 7, "MEDIUM": 0, "HIGH": 0},
-            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 7},
+            "SEVERITY": {"UNDEFINED": 0, "LOW": 8, "MEDIUM": 0, "HIGH": 0},
+            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 8},
         }
         self.check_example("random_module.py", expect)
 


### PR DESCRIPTION
The lowercase `random.random` already matches `random.Random` on Windows as well
(due to being case-insensitive), but not on other platforms.

Resolves #926.