### PR TITLE
* bandit/cli/main.py: Set log level to ERROR if -q option is passed.

### DIFF
--- a/bandit/cli/main.py
+++ b/bandit/cli/main.py
@@ -603,7 +603,7 @@ def main():
         _init_logger(log_level=logging.DEBUG, log_format=log_format)
 
     if args.quiet:
-        _init_logger(log_level=logging.WARN)
+        _init_logger(log_level=logging.ERROR)
 
     try:
         profile = _get_profile(b_conf, args.profile, args.config_file)


### PR DESCRIPTION
Fixes #907