### PR TITLE
remove py2 exec example in docs

### DIFF
--- a/bandit/formatters/xml.py
+++ b/bandit/formatters/xml.py
@@ -33,8 +33,6 @@ This formatter outputs the issues as XML.
     New field `CWE` added to output
 
 """
-# This future import is necessary here due to the xml import below on Python
-# 2.7
 import logging
 import sys
 from xml.etree import cElementTree as ET

--- a/bandit/plugins/exec.py
+++ b/bandit/plugins/exec.py
@@ -19,7 +19,7 @@ Python docs succinctly describe why the use of `exec` is risky.
        CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
        Location: ./examples/exec.py:2
     1 exec("do evil")
-    2 exec "do evil"
+
 
 .. seealso::
 


### PR DESCRIPTION
Follow up to #933 to remove Python 2 code example
