### PR TITLE
Set constraint for importlib-metadata

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 # process, which may cause wedges in the gate later.
 GitPython>=1.0.1 # BSD License (3 clause)
 PyYAML>=5.3.1 # MIT
+importlib-metadata<5;python_version<"3.8" # Apache-2.0
 stevedore>=1.20.0 # Apache-2.0
 colorama>=0.3.9;platform_system=="Windows" # BSD License (3 clause)
 rich # MIT


### PR DESCRIPTION
If Python version is 3.7 or lower (i.e., `importlib.metadata` is not in the standard library) then third-party `importlib-metadata` must be installed. However `importlib-metadata` version 5.x no longer supports interface used by `stevedore` version 3.x. This change fixes this by constraining the version of `importlib-metadata` to 4.x.