### PR TITLE
Update config.rst pre-commit section to new format

### DIFF
--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -80,8 +80,11 @@ and optional additional dependencies in the `pre-commit`_ configuration:
       rev: '' # Update me!
       hooks:
       - id: bandit
-        args: ["-c", "pyproject.toml"]
-        additional_dependencies: ["bandit[toml]"]
+        args:
+          - '-c'
+          - 'pyproject.toml'
+        additional_dependencies: 
+          - 'bandit[toml]'
 
 Exclusions
 ----------


### PR DESCRIPTION
map format as produced by `pre-commit migrate-config`; the previous version no longer works with pre-config