### PR TITLE
Correct passenv in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
 commands =
     find bandit -type f -name "*.pyc" -delete
     stestr run {posargs}
-whitelist_externals =
+allowlist_externals =
     find
 passenv =
     http_proxy

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,13 @@ commands =
     stestr run {posargs}
 whitelist_externals =
     find
-passenv = http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY
+passenv =
+    http_proxy
+    HTTP_PROXY
+    https_proxy
+    HTTPS_PROXY
+    no_proxy
+    NO_PROXY
 
 [testenv:debug]
 commands = oslo_debug_helper -t tests {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,6 @@
 minversion = 3.2.0
 envlist = py37,pep8
 skipsdist = True
-requires =
-    tox<4
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
Signed-off-by: Gábor Lipták <gliptak@gmail.com>

https://github.com/PyCQA/bandit/actions/runs/3839481628/jobs/6537302402

```
format: failed with pass_env values cannot contain whitespace, use comma to have multiple values in a single line, invalid values found 'http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY'
```

https://packaging-guide.openastronomy.org/en/latest/tox.html?highlight=passenv#environment-variables