### PR TITLE
Fix breaking build due to new tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,9 @@
 [tox]
-minversion = 2.0
+minversion = 3.2.0
 envlist = py37,pep8
 skipsdist = True
+requires =
+    tox<4
 
 [testenv]
 usedevelop = True
@@ -14,7 +16,7 @@ deps =
 commands =
     find bandit -type f -name "*.pyc" -delete
     stestr run {posargs}
-whitelist_externals =
+allowlist_externals =
     find
 passenv = http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY
 


### PR DESCRIPTION
Version 4 of Tox is currently breaking the build. Therefore, until those issues are fixed, this change can revert to Tox 3.x.

Signed-off-by: Eric Brown <eric_wade_brown@yahoo.com>