### PR TITLE
Render Python 3.10 in drop down correctly

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -68,13 +68,13 @@ body:
       label: Python version
       description: Run "bandit --version" if unsure of version number
       options:
-        - 3.11 (Default)
-        - 3.10
-        - 3.9
-        - 3.8
-        - 3.7
-        - 3.6
-        - 3.5
+        - "3.11 (Default)"
+        - "3.10"
+        - "3.9"
+        - "3.8"
+        - "3.7"
+        - "3.6"
+        - "3.5"
     validations:
       required: true
 


### PR DESCRIPTION
This is a fix to properly render the 3.10 option in the Python version drop down. Markdown is rendering
3.10 as 3.1.