### PR TITLE
Add Additional testing on functionality of the Bandit tool #1005

### DIFF
--- a/tests/functional/test_baseline.py
+++ b/tests/functional/test_baseline.py
@@ -261,82 +261,32 @@ class BaselineFunctionalTests(testtools.TestCase):
         self.assertIn(baseline_no_skipped_files, return_value)
         self.assertIn(baseline_no_issues_found, return_value)
 
-    def test_new_candidates_include_nosec_only_nosecs(self):
-        """Test to check nosec references with new only nosec candidates
-
-        Test that nosec references are included during a baseline test, which
-        would normally be ignored. In this test case, there are new candidates
-        which are specifically nosec references.
-        """
-        self.baseline_commands.append("--ignore-nosec")
-        baseline_report_files = {
-            "new_candidates-nosec.py": "new_candidates-none.py"
-        }
-        target_directory, baseline_code = self._create_baseline(
-            baseline_report_files
-        )
-        # assert the initial baseline found nothing
-        self.assertEqual(0, baseline_code)
-        baseline_report = os.path.join(
-            target_directory, self.baseline_report_file
-        )
-        return_value, return_code = self._run_bandit_baseline(
-            target_directory, baseline_report
-        )
-        # assert there were results (candidates found)
-        self.assertEqual(1, return_code)
-        self.assertIn(new_candidates_some_total_lines, return_value)
-        self.assertIn(new_candidates_no_nosec_lines, return_value)
-        self.assertIn(baseline_no_skipped_files, return_value)
-        self.assertIn(xml_sax_issue_id, return_value)
-        self.assertIn(yaml_load_issue_id, return_value)
-        self.assertIn(shell_issue_id, return_value)
-        # candidate #2
-        self.assertIn(candidate_example_two, return_value)
-        # candidate #4
-        self.assertIn(candidate_example_four, return_value)
-        # candidate #6
-        self.assertIn(candidate_example_six, return_value)
-
-    def test_new_candidates_include_nosec_new_nosecs(self):
-        """Test to check nosec references with new candidates, including nosecs
-
-        Test that nosec references are included during a baseline test, which
-        would normally be ignored. In this test case, there are new candidates
-        that also includes new nosec references as well.
-        """
-        self.baseline_commands.append("--ignore-nosec")
-        baseline_report_files = {
-            "new_candidates-all.py": "new_candidates-none.py"
-        }
-        target_directory, baseline_code = self._create_baseline(
-            baseline_report_files
-        )
-        # assert the initial baseline found nothing
-        self.assertEqual(0, baseline_code)
-        baseline_report = os.path.join(
-            target_directory, self.baseline_report_file
-        )
-        return_value, return_code = self._run_bandit_baseline(
-            target_directory, baseline_report
-        )
-        # assert there were results (candidates found)
-        self.assertEqual(1, return_code)
-        self.assertIn(new_candidates_all_total_lines, return_value)
-        self.assertIn(new_candidates_no_nosec_lines, return_value)
-        self.assertIn(baseline_no_skipped_files, return_value)
-        self.assertIn(xml_sax_issue_id, return_value)
-        self.assertIn(yaml_load_issue_id, return_value)
-        self.assertIn(shell_issue_id, return_value)
-        # candidate #1
-        self.assertIn(candidate_example_one, return_value)
-        # candidate #2
-        self.assertIn(candidate_example_two, return_value)
-        # candidate #3
-        self.assertIn(candidate_example_three, return_value)
-        # candidate #4
-        self.assertIn(candidate_example_four, return_value)
-        # candidate #5
-        self.assertIn(candidate_example_five, return_value)
-        # candidate #6
-        self.assertIn(candidate_example_six, return_value)
+   def test_new_candidates(self):
+    """Tests when there are new candidates found
+    Test that bandit returns the new candidates found compared with those
+    in the baseline.
+    """
+    baseline_report_files = {
+        "new_candidates-all.py": "new_candidates-all.py"
+    }
+    target_directory, baseline_code = self._create_baseline(
+        baseline_report_files
+    )
+    # assert the initial baseline found results
+    self.assertEqual(1, baseline_code)
+    baseline_report = os.path.join(
+        target_directory, self.baseline_report_file
+    )
+    # modify the baseline file to add new candidates
+    with open(os.path.join(target_directory, "new_candidates-all.py"), "a") as f:
+        f.write("subprocess.check_output(['ls'])\n")
+    return_value, return_code = self._run_bandit_baseline(
+        target_directory, baseline_report
+    )
+    # assert there were new results (new candidates found)
+    self.assertEqual(1, return_code)
+    self.assertIn(new_candidates_all_total_lines, return_value)
+    self.assertIn(new_candidates_skip_nosec_lines, return_value)
+    self.assertIn("subprocess.check_output(['ls'])", return_value)
+    self.assertNotIn(baseline_no_issues_found, return_value)
+    self.assertNotIn(baseline_no_skipped_files, return_value)

--- a/tests/functional/test_baseline.py
+++ b/tests/functional/test_baseline.py
@@ -290,3 +290,30 @@ class BaselineFunctionalTests(testtools.TestCase):
     self.assertIn("subprocess.check_output(['ls'])", return_value)
     self.assertNotIn(baseline_no_issues_found, return_value)
     self.assertNotIn(baseline_no_skipped_files, return_value)
+
+def test_no_new_candidates(self):
+    """Tests when there are no new candidates
+    Test that bandit returns no issues found, as there are no new
+    candidates found compared with those found from the baseline.
+    """
+    baseline_report_files = {
+        "new_candidates-all.py": "new_candidates-all.py"
+    }
+    target_directory, baseline_code = self._create_baseline(
+        baseline_report_files
+    )
+    # assert the initial baseline found results
+    self.assertEqual(1, baseline_code)
+    baseline_report = os.path.join(
+        target_directory, self.baseline_report_file
+    )
+    return_value, return_code = self._run_bandit_baseline(
+        target_directory, baseline_report
+    )
+    # assert there were no results (no candidates found)
+    self.assertEqual(0, return_code)
+    self.assertIn(new_candidates_all_total_lines, return_value)
+    self.assertIn(new_candidates_skip_nosec_lines, return_value)
+    self.assertIn(baseline_no_skipped_files, return_value)
+    self.assertIn(baseline_no_issues_found, return_value)
+


### PR DESCRIPTION
Is your feature request related to a problem? Please describe.
test_no_new_candidates().
To improve the functional test suite, you can add additional test cases for the remaining functionality of the Bandit tool. Here are some suggestions for additional test cases

Describe alternatives you've considered
Considering all of these test cases id like to implement:

Test, when there are new candidates, found compared with those in the baseline. This should return the new candidate details along with the candidates from the baseline.

Test when a candidate has a # nosec comment added and that candidate was previously flagged as an issue in the baseline. This should not return that candidate in the results.

Test when a candidate has been fixed in the code and should no longer be flagged as an issue in the baseline. This should not return that candidate in the results.

Additional context