### PR TITLE
Improper detection of non-requests module

### DIFF
--- a/bandit/plugins/request_without_timeout.py
+++ b/bandit/plugins/request_without_timeout.py
@@ -52,10 +52,9 @@ from bandit.core import test_properties as test
 @test.test_id("B113")
 def request_without_timeout(context):
     http_verbs = ("get", "options", "head", "post", "put", "patch", "delete")
-    if (
-        "requests" in context.call_function_name_qual
-        and context.call_function_name in http_verbs
-    ):
+    qualname = context.call_function_name_qual.split(".")[0]
+
+    if qualname == "requests" and context.call_function_name in http_verbs:
         # check for missing timeout
         if context.check_call_arg_value("timeout") is None:
             return bandit.Issue(

--- a/examples/requests-missing-timeout.py
+++ b/examples/requests-missing-timeout.py
@@ -1,4 +1,5 @@
 import requests
+import not_requests
 
 requests.get('https://gmail.com')
 requests.get('https://gmail.com', timeout=None)
@@ -21,3 +22,6 @@ requests.options('https://gmail.com', timeout=5)
 requests.head('https://gmail.com')
 requests.head('https://gmail.com', timeout=None)
 requests.head('https://gmail.com', timeout=5)
+
+# Okay
+not_requests.get('https://gmail.com')


### PR DESCRIPTION
Fixes false postive detecting the usage of the requests module without a timeout. This resolves cases of modules with the word "requests" in the name, but does not match the actual popular third-party module "requests".

The fix checks the fully qualified name and ensures index 0 is "requests". Previously, the code was match any module name with "requests" in it.

Fixes #1010