### PR TITLE
xmlrpclib replaced with xmlrpc in Python3

### DIFF
--- a/bandit/blacklists/imports.py
+++ b/bandit/blacklists/imports.py
@@ -152,7 +152,7 @@ xmlrpclib and mitigate remote XML attacks.
 +------+---------------------+------------------------------------+-----------+
 | ID   |  Name               |  Imports                           |  Severity |
 +======+=====================+====================================+===========+
-| B411 | import_xmlrpclib    | - xmlrpclib                        | high      |
+| B411 | import_xmlrpclib    | - xmlrpc                           | high      |
 +------+---------------------+------------------------------------+-----------+
 
 B412: import_httpoxy
@@ -374,7 +374,7 @@ def gen_blacklist():
             "import_xmlrpclib",
             "B411",
             issue.Cwe.IMPROPER_INPUT_VALIDATION,
-            ["xmlrpclib"],
+            ["xmlrpc"],
             "Using {name} to parse untrusted XML data is known to be "
             "vulnerable to XML attacks. Use defused.xmlrpc.monkey_patch() "
             "function to monkey-patch xmlrpclib and mitigate XML "

--- a/examples/xml_xmlrpc.py
+++ b/examples/xml_xmlrpc.py
@@ -1,4 +1,4 @@
-import xmlrpclib
+import xmlrpc
 from SimpleXMLRPCServer import SimpleXMLRPCServer
 
 def is_even(n):


### PR DESCRIPTION
The xmlrpclib of Python 2.x was replaced in Python 3 with xmlrpc [1]. Since Bandit no longer supports Python 2.x, it needs to update to the latest module name.

As indicted in [2], xmlrpc is still not secure against maliciously constructed data.

[1] https://python.readthedocs.io/en/v2.7.2/library/xmlrpclib.html
[2] https://docs.python.org/3/library/xmlrpc.client.html#module-xmlrpc.client