### PR TITLE
Replace pbr in favor of importlib

### DIFF
--- a/bandit/__init__.py
+++ b/bandit/__init__.py
@@ -2,7 +2,10 @@
 # Copyright 2014 Hewlett-Packard Development Company, L.P.
 #
 # SPDX-License-Identifier: Apache-2.0
-import pbr.version
+try:
+    from importlib import metadata
+except ImportError:
+    import importlib_metadata as metadata
 
 from bandit.core import config  # noqa
 from bandit.core import context  # noqa
@@ -16,4 +19,4 @@ from bandit.core.constants import *  # noqa
 from bandit.core.issue import *  # noqa
 from bandit.core.test_properties import *  # noqa
 
-__version__ = pbr.version.VersionInfo("bandit").version_string()
+__version__ = metadata.version("bandit")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ PyYAML>=5.3.1 # MIT
 stevedore>=1.20.0 # Apache-2.0
 colorama>=0.3.9;platform_system=="Windows" # BSD License (3 clause)
 rich # MIT
+importlib-metadata;python_version<"3.8" # Apache-2.0


### PR DESCRIPTION
The importlib module has a metadata.version to retrieve the package version of the given module. This can be used in lieu of pbr for gathering versioning. As a result we can drop the runtime dependency on pbr.

Fixes #839
Fixes #735