### PR TITLE
Skip unnecessary `pip install` commands in the pythonpackage.yml workflow

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -18,8 +18,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r test-requirements.txt
         pip install tox
     - name: Run tox
       run: tox run -e format
@@ -41,8 +39,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r test-requirements.txt
         pip install tox
     - name: Run tox
       run: tox run -e pep8
@@ -66,8 +62,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r test-requirements.txt
         pip install tox
     - name: Run tox
       run: tox run -e py${{ matrix.python-version[1] }}


### PR DESCRIPTION
All checks in pythonpackage.yml are run by tox. Manual installation of requirements is unnecessary here, as tox will install and run everything in separate virtual environments.