### PR TITLE
fix: correct no-prefix no-suffix exclude for top-level dirs (#975)

### DIFF
--- a/bandit/core/manager.py
+++ b/bandit/core/manager.py
@@ -216,9 +216,6 @@ class BanditManager:
         # if there are command line provided exclusions add them to the list
         if excluded_paths:
             for path in excluded_paths.split(","):
-                if os.path.isdir(path):
-                    path = os.path.join(path, "*")
-
                 excluded_path_globs.append(path)
 
         # build list of files we will analyze

--- a/bandit/core/manager.py
+++ b/bandit/core/manager.py
@@ -215,8 +215,7 @@ class BanditManager:
 
         # if there are command line provided exclusions add them to the list
         if excluded_paths:
-            for path in excluded_paths.split(","):
-                excluded_path_globs.append(path)
+            excluded_path_globs.extend(excluded_paths.split(","))
 
         # build list of files we will analyze
         for fname in targets:
@@ -401,24 +400,15 @@ def _is_file_included(
     :param enforce_glob: Can set to false to bypass extension check
     :return: Boolean indicating whether a file should be included
     """
-    return_value = False
-
-    # if this is matches a glob of files we look at, and it isn't in an
-    # excluded path
-    if _matches_glob_list(path, included_globs) or not enforce_glob:
-        if not _matches_glob_list(path, excluded_path_strings) and not any(
-            x in path for x in excluded_path_strings
-        ):
-            return_value = True
-
-    return return_value
+    if enforce_glob and not _matches_glob_list(path, included_globs):
+        return False
+    if _matches_glob_list(path, excluded_path_strings):
+        return False
+    return not any(x in path for x in excluded_path_strings)
 
 
 def _matches_glob_list(filename, glob_list):
-    for glob in glob_list:
-        if fnmatch.fnmatch(filename, glob):
-            return True
-    return False
+    return any(fnmatch.fnmatch(filename, glob) for glob in glob_list)
 
 
 def _compare_baseline_results(baseline, results):

--- a/tests/unit/core/test_manager.py
+++ b/tests/unit/core/test_manager.py
@@ -266,7 +266,13 @@ class ManagerTests(testtools.TestCase):
         self.assertEqual([], self.manager.files_list)
         self.assertEqual(["./x/y.py"], self.manager.excluded_files)
 
-        # Test exclude dir without prefix or suffix
+        # Test exclude top-level dir without prefix or suffix
+        isdir.side_effect = [True, False]
+        self.manager.discover_files(["./x/y/z.py"], True, "x")
+        self.assertEqual([], self.manager.files_list)
+        self.assertEqual(["./x/y/z.py"], self.manager.excluded_files)
+
+        # Test exclude lower-level dir without prefix or suffix
         isdir.side_effect = [False, False]
         self.manager.discover_files(["./x/y/z.py"], True, "y")
         self.assertEqual([], self.manager.files_list)

--- a/tests/unit/core/test_manager.py
+++ b/tests/unit/core/test_manager.py
@@ -255,25 +255,25 @@ class ManagerTests(testtools.TestCase):
         self.assertEqual(["./x/y.py"], self.manager.excluded_files)
 
         # Test exclude dir without wildcard
-        isdir.side_effect = [True, False]
+        isdir.side_effect = [False]
         self.manager.discover_files(["./x/y.py"], True, "./x/")
         self.assertEqual([], self.manager.files_list)
         self.assertEqual(["./x/y.py"], self.manager.excluded_files)
 
         # Test exclude dir without wildcard or trailing slash
-        isdir.side_effect = [True, False]
+        isdir.side_effect = [False]
         self.manager.discover_files(["./x/y.py"], True, "./x")
         self.assertEqual([], self.manager.files_list)
         self.assertEqual(["./x/y.py"], self.manager.excluded_files)
 
         # Test exclude top-level dir without prefix or suffix
-        isdir.side_effect = [True, False]
+        isdir.side_effect = [False]
         self.manager.discover_files(["./x/y/z.py"], True, "x")
         self.assertEqual([], self.manager.files_list)
         self.assertEqual(["./x/y/z.py"], self.manager.excluded_files)
 
         # Test exclude lower-level dir without prefix or suffix
-        isdir.side_effect = [False, False]
+        isdir.side_effect = [False]
         self.manager.discover_files(["./x/y/z.py"], True, "y")
         self.assertEqual([], self.manager.files_list)
         self.assertEqual(["./x/y/z.py"], self.manager.excluded_files)


### PR DESCRIPTION
Bandit 1.7.5 has some inconsistent behaviour. Assume a directory with just one subdirectory in it, which in turn contains a single file: `./tests/build.py`

The following behaviour is observed:
- `bandit . -vrx ./tests` ignores the file,
- `bandit . -vrx test` ignores the file,
- `bandit . -vrx tests` does NOT ignore the file.

This PR removes the internal tweaking of an excluded path if the path is a directory.

No breaking change is foreseen.

Closes #975