### PR TITLE
Make pre-commit run Bandit hook using a single process

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,3 +5,4 @@
     language: python
     language_version: python3
     types: [python]
+    require_serial: true


### PR DESCRIPTION
I would like you to consider this small change to the pre-commit manifest. 

Currently pre-commit may run Bandit hook with multiple processes, which can lead to Bandit generating multiple reports from these runs. It's only a bit confusing when you run Bandit for the first time on a moderately large database and output report on the screen, but it's much worse if you're saving your report to, let's say, an HTML file. Then you would get a straight wrong report.

This is what happens, when I run the same Bandit command with pre-commit and without it on the same codebase:

**(pre-commit)**
![Screenshot from 2023-05-23 02-23-31](https://github.com/PyCQA/bandit/assets/56698047/8d625af6-c5e6-4f56-a6d7-c22b859fcaba)

**(w/o pre-commit)**
![Screenshot from 2023-05-23 02-24-11](https://github.com/PyCQA/bandit/assets/56698047/46c40e37-1f8d-4be5-b8c1-2b98c4fa7805)

Each run just overwrites the report file, and in the end we're left with what happens to be the latest run result. 

One can mitigate this problem by using the `-r` flag and setting pre-commit `pass_filenames` option to `false`, but this doesn't suit everyone (or should be at least documented).
