### PR TITLE
Add a copy button to all code snippets in docs

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,3 +3,4 @@
 # process, which may cause wedges in the gate later.
 sphinx>=4.0.0 # BSD
 sphinx-rtd-theme>=0.3.0
+sphinx-copybutton

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -12,6 +12,7 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.coverage",
     "sphinx.ext.viewcode",
+    "sphinx_copybutton",
 ]
 
 # autodoc generation is a bit aggressive and a nuisance when doing heavy


### PR DESCRIPTION
There is a sphinx extension (sphinx_copybutton) that enables a copy button for every code-block included in our docs. This is a nice and easy usability change.

https://sphinx-copybutton.readthedocs.io/en/latest/
https://github.com/executablebooks/sphinx-copybutton
https://pypi.org/project/sphinx-copybutton/