### PR TITLE
Switch from open collective to PSF

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,2 @@
-# These are supported funding model platforms
-open_collective: bandit-sast
+custom: ["https://psfmember.org/civicrm/contribute/transact/?reset=1&id=42"]
 github: [ericwb]


### PR DESCRIPTION
This change adds Python Software Foundation as the link for fiscal sponsorship. Now that Bandit is a member of the fiscal sponsorees, we can accept donations through their channels.

This also means, we need to remove the Open Collective option as it would conflict with PSF.

https://www.python.org/psf/fiscal-sponsorees/