### PR TITLE
Remove support for Python 3.7 due to end-of-life

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,10 +10,10 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Install dependencies
       run: pip install wheel

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -10,10 +10,10 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Install dependencies
       run: pip install wheel

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         python-version: [
-          ["3.7", "37"], ["3.8", "38"], ["3.9", "39"], ["3.10", "310"], ["3.11", "311"]
+          ["3.8", "38"], ["3.9", "39"], ["3.10", "310"], ["3.11", "311"]
         ]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,17 +11,17 @@ repos:
   rev: v3.9.0
   hooks:
   - id: reorder-python-imports
-    args: [--application-directories, '.:src', --py37-plus]
+    args: [--application-directories, '.:src', --py38-plus]
 - repo: https://github.com/psf/black
   rev: 23.3.0
   hooks:
   - id: black
-    args: [--line-length=79, --target-version=py37]
+    args: [--line-length=79, --target-version=py38]
 - repo: https://github.com/asottile/pyupgrade
   rev: v3.3.2
   hooks:
   - id: pyupgrade
-    args: [--py37-plus]
+    args: [--py38-plus]
 - repo: https://github.com/jorisroovers/gitlint
   rev: v0.19.1
   hooks:

--- a/bandit/core/utils.py
+++ b/bandit/core/utils.py
@@ -219,7 +219,7 @@ def calc_linerange(node):
 
 def linerange(node):
     """Get line number range from a node."""
-    if sys.version_info >= (3, 8) and hasattr(node, "lineno"):
+    if hasattr(node, "lineno"):
         return list(range(node.lineno, node.end_lineno + 1))
     else:
         if hasattr(node, "_bandit_linerange_stripped"):

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifier =
     Operating System :: MacOS :: MacOS X
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10

--- a/setup.py
+++ b/setup.py
@@ -4,5 +4,5 @@
 import setuptools
 
 setuptools.setup(
-    python_requires=">=3.7", setup_requires=["pbr>=2.0.0"], pbr=True
+    python_requires=">=3.8", setup_requires=["pbr>=2.0.0"], pbr=True
 )

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -461,18 +461,6 @@ class FunctionalTests(testtools.TestCase):
         severity_medium_tests = 26
         nosec_tests = 7
         skipped_tests = 8
-        if sys.version_info[:2] <= (3, 7):
-            # In the case of implicit concatenation in python 3.7,
-            # we know only the first line of multi-line string.
-            # Thus, cases like:
-            # query = ("SELECT * "
-            #          "FROM foo "  # nosec
-            #          f"WHERE id = {identifier}")
-            # are not skipped but reported as errors.
-            confidence_low_tests = 17
-            severity_medium_tests = 30
-            nosec_tests = 5
-            skipped_tests = 6
         expect = {
             "SEVERITY": {
                 "UNDEFINED": 0,
@@ -790,19 +778,13 @@ class FunctionalTests(testtools.TestCase):
             issues[0].fname.endswith("examples/multiline_statement.py")
         )
         self.assertEqual(1, issues[0].lineno)
-        if sys.version_info >= (3, 8):
-            self.assertEqual(list(range(1, 2)), issues[0].linerange)
-        else:
-            self.assertEqual(list(range(1, 3)), issues[0].linerange)
+        self.assertEqual(list(range(1, 2)), issues[0].linerange)
         self.assertIn("subprocess", issues[0].get_code())
         self.assertEqual(5, issues[1].lineno)
         self.assertEqual(list(range(3, 6 + 1)), issues[1].linerange)
         self.assertIn("shell=True", issues[1].get_code())
         self.assertEqual(11, issues[2].lineno)
-        if sys.version_info >= (3, 8):
-            self.assertEqual(list(range(8, 13 + 1)), issues[2].linerange)
-        else:
-            self.assertEqual(list(range(8, 12 + 1)), issues[2].linerange)
+        self.assertEqual(list(range(8, 13 + 1)), issues[2].linerange)
         self.assertIn("shell=True", issues[2].get_code())
 
     def test_code_line_numbers(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.2.0
-envlist = py37,pep8
+envlist = py38,pep8
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
Python 3.7 was end-of-life as of 6-27-2023. As such, there is no need for Bandit to continue to support it.

Fixes #992