### PR TITLE
Flag str.replace as possible sql injection

### DIFF
--- a/bandit/plugins/injection_sql.py
+++ b/bandit/plugins/injection_sql.py
@@ -52,6 +52,9 @@ If so, a MEDIUM issue is reported. For example:
 .. versionchanged:: 1.7.3
     CWE information added
 
+.. versionchanged:: 1.7.6
+    Flag when str.replace is used in the string construction
+
 """  # noqa: E501
 import ast
 import re
@@ -84,7 +87,7 @@ def _evaluate_ast(node):
         statement = out[1]
     elif (
         isinstance(node._bandit_parent, ast.Attribute)
-        and node._bandit_parent.attr == "format"
+        and node._bandit_parent.attr in ("format", "replace")
     ):
         statement = node.s
         # Hierarchy for "".format() is Wrapper -> Call -> Attribute -> Str
@@ -108,9 +111,9 @@ def _evaluate_ast(node):
     if isinstance(wrapper, ast.Call):  # wrapped in "execute" call?
         names = ["execute", "executemany"]
         name = utils.get_called_name(wrapper)
-        return (name in names, statement)
+        return name in names, statement
     else:
-        return (False, statement)
+        return False, statement
 
 
 @test.checks("Str")

--- a/bandit/plugins/injection_sql.py
+++ b/bandit/plugins/injection_sql.py
@@ -59,7 +59,7 @@ for false positives, since valid ues of str.replace can be common.
 .. versionchanged:: 1.7.3
     CWE information added
 
-.. versionchanged:: 1.7.6
+.. versionchanged:: 1.7.7
     Flag when str.replace is used in the string construction
 
 """  # noqa: E501

--- a/bandit/plugins/injection_sql.py
+++ b/bandit/plugins/injection_sql.py
@@ -111,9 +111,9 @@ def _evaluate_ast(node):
     if isinstance(wrapper, ast.Call):  # wrapped in "execute" call?
         names = ["execute", "executemany"]
         name = utils.get_called_name(wrapper)
-        return name in names, statement
+        return (name in names, statement)
     else:
-        return False, statement
+        return (False, statement)
 
 
 @test.checks("Str")

--- a/bandit/plugins/injection_sql.py
+++ b/bandit/plugins/injection_sql.py
@@ -33,7 +33,7 @@ For example:
 - "SELECT * FROM foo WHERE id = '[VALUE]'".replace("[VALUE]", identifier)
 
 However, such cases are always reported with LOW confidence to compensate
-for false positives, since valid ues of str.replace can be common.
+for false positives, since valid uses of str.replace can be common.
 
 :Example:
 

--- a/bandit/plugins/injection_sql.py
+++ b/bandit/plugins/injection_sql.py
@@ -85,10 +85,9 @@ def _evaluate_ast(node):
         out = utils.concat_string(node, node._bandit_parent)
         wrapper = out[0]._bandit_parent
         statement = out[1]
-    elif (
-        isinstance(node._bandit_parent, ast.Attribute)
-        and node._bandit_parent.attr in ("format", "replace")
-    ):
+    elif isinstance(
+        node._bandit_parent, ast.Attribute
+    ) and node._bandit_parent.attr in ("format", "replace"):
         statement = node.s
         # Hierarchy for "".format() is Wrapper -> Call -> Attribute -> Str
         wrapper = node._bandit_parent._bandit_parent._bandit_parent

--- a/examples/sql_statements.py
+++ b/examples/sql_statements.py
@@ -10,6 +10,7 @@ SELECT x FROM cte WHERE x = '%s'""" % identifier
 # bad alternate forms
 query = "SELECT * FROM foo WHERE id = '" + identifier + "'"
 query = "SELECT * FROM foo WHERE id = '{}'".format(identifier)
+query = "SELECT * FROM foo WHERE id = '[VALUE]'".replace("[VALUE]", identifier)
 
 # bad
 cur.execute("SELECT * FROM foo WHERE id = '%s'" % identifier)
@@ -19,6 +20,7 @@ cur.execute("UPDATE foo SET value = 'b' WHERE id = '%s'" % identifier)
 # bad alternate forms
 cur.execute("SELECT * FROM foo WHERE id = '" + identifier + "'")
 cur.execute("SELECT * FROM foo WHERE id = '{}'".format(identifier))
+cur.execute("SELECT * FROM foo WHERE id = '[VALUE]'".replace("[VALUE]", identifier))
 
 # bad f-strings
 cur.execute(f"SELECT {column_name} FROM foo WHERE id = 1")

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -444,8 +444,8 @@ class FunctionalTests(testtools.TestCase):
             },
             "CONFIDENCE": {
                 "UNDEFINED": 0,
-                "LOW": 9,
-                "MEDIUM": 11,
+                "LOW": 10,
+                "MEDIUM": 10,
                 "HIGH": 0,
             },
         }

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -439,13 +439,13 @@ class FunctionalTests(testtools.TestCase):
             "SEVERITY": {
                 "UNDEFINED": 0,
                 "LOW": 0,
-                "MEDIUM": 18,
+                "MEDIUM": 20,
                 "HIGH": 0,
             },
             "CONFIDENCE": {
                 "UNDEFINED": 0,
-                "LOW": 8,
-                "MEDIUM": 10,
+                "LOW": 9,
+                "MEDIUM": 11,
                 "HIGH": 0,
             },
         }


### PR DESCRIPTION
This extends the existing implementation for detecting possible cases of SQL injection to account for `str.replace` used in the string construction.

Use of `str.replace` can lead to SQL injection in much the same way as `str.format` can, and that is already considered in the pre-existing implementation, along with other common string constructions.

Resolves #878