### PR TITLE
Support ignoring blacklists by name

### DIFF
--- a/bandit/core/config.py
+++ b/bandit/core/config.py
@@ -148,8 +148,8 @@ class BanditConfig:
         updated_profiles = {}
         for name, profile in (self.get_option("profiles") or {}).items():
             # NOTE(tkelsey): can't use default of get() because value is
-            # sometimes explicitly 'None', for example when the list is given in
-            # yaml but not populated with any values.
+            # sometimes explicitly 'None', for example when the list is given
+            # in yaml but not populated with any values.
             include = {
                 (extman.get_test_id(i) or i)
                 for i in (profile.get("include") or [])

--- a/bandit/core/config.py
+++ b/bandit/core/config.py
@@ -148,14 +148,14 @@ class BanditConfig:
         updated_profiles = {}
         for name, profile in (self.get_option("profiles") or {}).items():
             # NOTE(tkelsey): can't use default of get() because value is
-            # sometimes explicity 'None', for example when the list if given in
+            # sometimes explicitly 'None', for example when the list is given in
             # yaml but not populated with any values.
             include = {
-                (extman.get_plugin_id(i) or i)
+                (extman.get_test_id(i) or i)
                 for i in (profile.get("include") or [])
             }
             exclude = {
-                (extman.get_plugin_id(i) or i)
+                (extman.get_test_id(i) or i)
                 for i in (profile.get("exclude") or [])
             }
             updated_profiles[name] = {"include": include, "exclude": exclude}

--- a/bandit/core/extension_loader.py
+++ b/bandit/core/extension_loader.py
@@ -53,11 +53,11 @@ class Manager:
         self.plugins_by_id = {p.plugin._test_id: p for p in self.plugins}
         self.plugins_by_name = {p.name: p for p in self.plugins}
 
-    def get_plugin_id(self, plugin_name):
-        if plugin_name in self.plugins_by_name:
-            return self.plugins_by_name[plugin_name].plugin._test_id
-        if plugin_name in self.blacklist_by_name:
-            return self.blacklist_by_name[plugin_name]["id"]
+    def get_test_id(self, test_name):
+        if test_name in self.plugins_by_name:
+            return self.plugins_by_name[test_name].plugin._test_id
+        if test_name in self.blacklist_by_name:
+            return self.blacklist_by_name[test_name]["id"]
         return None
 
     def load_blacklists(self, blacklist_namespace):

--- a/bandit/core/extension_loader.py
+++ b/bandit/core/extension_loader.py
@@ -56,6 +56,8 @@ class Manager:
     def get_plugin_id(self, plugin_name):
         if plugin_name in self.plugins_by_name:
             return self.plugins_by_name[plugin_name].plugin._test_id
+        if plugin_name in self.blacklist_by_name:
+            return self.blacklist_by_name[plugin_name]["id"]
         return None
 
     def load_blacklists(self, blacklist_namespace):

--- a/bandit/core/manager.py
+++ b/bandit/core/manager.py
@@ -460,17 +460,17 @@ def _find_candidate_matches(unmatched_issues, results_list):
 
 
 def _find_test_id_from_nosec_string(extman, match):
-    plugin_id = extman.check_id(match)
-    if plugin_id:
+    test_id = extman.check_id(match)
+    if test_id:
         return match
-    # Finding by short_id didn't work, let's check the plugin name
-    plugin_id = extman.get_plugin_id(match)
-    if not plugin_id:
+    # Finding by short_id didn't work, let's check the test name
+    test_id = extman.get_test_id(match)
+    if not test_id:
         # Name and short id didn't work:
         LOG.warning(
             "Test in comment: %s is not a test name or id, ignoring", match
         )
-    return plugin_id  # We want to return None or the string here regardless
+    return test_id  # We want to return None or the string here regardless
 
 
 def _parse_nosec_comment(comment):

--- a/bandit/core/manager.py
+++ b/bandit/core/manager.py
@@ -25,7 +25,7 @@ from bandit.core import test_set as b_test_set
 
 LOG = logging.getLogger(__name__)
 NOSEC_COMMENT = re.compile(r"#\s*nosec:?\s*(?P<tests>[^#]+)?#?")
-NOSEC_COMMENT_TESTS = re.compile(r"(?:(B\d+|[a-z_]+),?)+", re.IGNORECASE)
+NOSEC_COMMENT_TESTS = re.compile(r"(?:(B\d+|[a-z\d_]+),?)+", re.IGNORECASE)
 PROGRESS_THRESHOLD = 50
 
 

--- a/examples/nosec.py
+++ b/examples/nosec.py
@@ -1,3 +1,6 @@
+import subprocess  # nosec: import_subprocess
+from cryptography.hazmat.primitives import hashes
+hashes.SHA1()  # nosec: md5
 subprocess.Popen('/bin/ls *', shell=True) #nosec (on the line)
 subprocess.Popen('/bin/ls *', #nosec (at the start of function call)
                  shell=True)


### PR DESCRIPTION
This extends nosec parsing to enable blacklists to be ignored by their name, not just by id.

There were 2 issues with the previous implementation:
1. The regex did not match numbers, which is needed for some names, such as md5. The code would only match "md" in this case.
2. The function that maps plugin names to ids only considered plugins but not blacklists.

Both of these are now addressed.

Closes #988