### PR TITLE
Avoid GitPython CVE-2023-40267

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # The order of packages is significant, because pip processes them in the order
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
-GitPython>=3.1.30 # BSD License (3 clause)
+GitPython>=3.1.32 # BSD License (3 clause)
 PyYAML>=5.3.1 # MIT
 stevedore>=1.20.0 # Apache-2.0
 colorama>=0.3.9;platform_system=="Windows" # BSD License (3 clause)


### PR DESCRIPTION
Bump GitPython to 3.1.32
Avoids [CVE-2023-40267](https://github.com/advisories/GHSA-pr76-5cm5-w9cj)

