### PR TITLE
Fix dependabot to update github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
----
 version: 2
 updates:
+
   - package-ecosystem: "github-actions"
     directory: "/"
-    interval:
-      schedule: "monthly"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
The dependabot.yml file isn't enabling dependabot checks for some reason. This change updates
the file to match the example given by the GitHub documentation more closely.

I suspect the issue is the swapped keys of `schedule` and `interval`.

This change also modifies the schedule of update checks to weekly instead of monthly.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#example-dependabotyml-file-for-github-actions