### PR TITLE
Fix for ReadtheDocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
+sphinx:
+  configuration: doc/source/conf.py
+
+python:
+  install:
+    - requirements: requirements.txt
+    - requirements: doc/requirements.txt


### PR DESCRIPTION
The ReadtheDocs build is currently failing because it is unable to find sphinx_copybutton. This occurs because ReadtheDocs by default will only install dependencies of the default requirements.txt at the root.

The fix needs to install the sphinx_copybutton package found in doc/requirements.txt. ReadtheDocsv2 now provides a better configuration using a YAML file [1] instead of just the UI and its limited options.

This change adds the new .readthedocs.yaml file that allows us to control what dependencies are installed via two requirements.txt files, one in root and one in doc/.

[1] https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os