### PR TITLE
Use mirror repository for black pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,8 @@ repos:
   hooks:
   - id: reorder-python-imports
     args: [--application-directories, '.:src', --py38-plus]
-- repo: https://github.com/psf/black
-  rev: 23.3.0
+- repo: https://github.com/psf/black-pre-commit-mirror
+  rev: 23.10.1
   hooks:
   - id: black
     args: [--line-length=79, --target-version=py38]


### PR DESCRIPTION
The docs of `black` recommends using a special mirror repository for the pre-commit hook.

More info:
https://black.readthedocs.io/en/stable/integrations/source_version_control.html#version-control-integration
https://github.com/psf/black/blob/main/CHANGES.md#integrations-3
