### PR TITLE
Fix crash on pyproject.toml without bandit config

### DIFF
--- a/bandit/core/config.py
+++ b/bandit/core/config.py
@@ -52,7 +52,9 @@ class BanditConfig:
 
                 try:
                     with f:
-                        self._config = tomllib.load(f).get("tool", {}).get("bandit", {})
+                        self._config = (
+                            tomllib.load(f).get("tool", {}).get("bandit", {})
+                        )
                 except tomllib.TOMLDecodeError as err:
                     LOG.error(err)
                     raise utils.ConfigError("Error parsing file.", config_file)

--- a/bandit/core/config.py
+++ b/bandit/core/config.py
@@ -52,7 +52,7 @@ class BanditConfig:
 
                 try:
                     with f:
-                        self._config = tomllib.load(f)["tool"]["bandit"]
+                        self._config = tomllib.load(f).get("tool", {}).get("bandit", {})
                 except tomllib.TOMLDecodeError as err:
                     LOG.error(err)
                     raise utils.ConfigError("Error parsing file.", config_file)


### PR DESCRIPTION
This is a naive fix for bandit crashing when it encounters a `pyproject.toml` which does not contain any specific bandit configuration.

This resolves the common failure mode that is seen, but does not cause bandit to fall back to another configuration source if the `pyproject.toml` does not contain any `tool.bandit` block.

Resolves #1027