### PR TITLE
Handle variant in how policy is passed in paramiko

### DIFF
--- a/bandit/plugins/ssh_no_host_key_verification.py
+++ b/bandit/plugins/ssh_no_host_key_verification.py
@@ -55,8 +55,13 @@ def ssh_no_host_key_verification(context):
         policy_argument_value = None
         if isinstance(policy_argument, ast.Attribute):
             policy_argument_value = policy_argument.attr
+        elif isinstance(policy_argument, ast.Name):
+            policy_argument_value = policy_argument.id
         elif isinstance(policy_argument, ast.Call):
-            policy_argument_value = policy_argument.func.attr
+            if isinstance(policy_argument.func, ast.Attribute):
+                policy_argument_value = policy_argument.func.attr
+            elif isinstance(policy_argument.func, ast.Name):
+                policy_argument_value = policy_argument.func.id
 
         if policy_argument_value in ["AutoAddPolicy", "WarningPolicy"]:
             return bandit.Issue(

--- a/examples/no_host_key_verification.py
+++ b/examples/no_host_key_verification.py
@@ -1,7 +1,14 @@
 from paramiko import client
+from paramiko import AutoAddPolicy
+from paramiko import WarningPolicy
 
 ssh_client = client.SSHClient()
 ssh_client.set_missing_host_key_policy(client.AutoAddPolicy)
 ssh_client.set_missing_host_key_policy(client.WarningPolicy)
 ssh_client.set_missing_host_key_policy(client.AutoAddPolicy())
 ssh_client.set_missing_host_key_policy(client.WarningPolicy())
+
+ssh_client.set_missing_host_key_policy(AutoAddPolicy)
+ssh_client.set_missing_host_key_policy(WarningPolicy)
+ssh_client.set_missing_host_key_policy(AutoAddPolicy())
+ssh_client.set_missing_host_key_policy(WarningPolicy())

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -543,8 +543,8 @@ class FunctionalTests(testtools.TestCase):
     def test_host_key_verification(self):
         """Test for ignoring host key verification."""
         expect = {
-            "SEVERITY": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 4},
-            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 4, "HIGH": 0},
+            "SEVERITY": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 8},
+            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 8, "HIGH": 0},
         }
         self.check_example("no_host_key_verification.py", expect)
 


### PR DESCRIPTION
Paramiko permits various ways of importing the missing host key policy. It allows paramiko.client.AutoAddPolicy or paramiko.AutoAddPolicy. The later isn't being handled in Bandit.

This change adds news tests and modifies the plugin to inspect the AST to determine whether the argument is an Attribute, Name, or Call.

Fixes #1077