### PR TITLE
Add tidelift to the sponsor funding list

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,3 @@
 custom: ["https://psfmember.org/civicrm/contribute/transact/?reset=1&id=42"]
 github: [ericwb]
+tidelift: pypi/bandit


### PR DESCRIPTION
Now that Tidelift is officially lifting Bandit, we should include it in our sponsor links.