### PR TITLE
Create a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+Bandit is a tool designed to find security issues, so every effort is made that Bandit itself is also
+free of those issues. However, if you believe you have found a security vulnerability in this repository
+please open it privately via the [Report a security vulnerability](https://github.com/PyCQA/bandit/security/advisories/new) link in the Issues tab.
+
+**Please do not report security vulnerabilities through public issues, discussions, or pull requests.**
+
+Please also inform the [Tidelift security](https://tidelift.com/security). Tidelift will help coordinate the fix and disclosure.


### PR DESCRIPTION
We really should provide guidance on how to open a security issue on Bandit itself.

Tidelift also requires a security policy document that they can refer to and help coordinate for their customers.