### PR TITLE
Prepend ./ for files specified as CLI args

### DIFF
--- a/bandit/core/manager.py
+++ b/bandit/core/manager.py
@@ -249,6 +249,8 @@ class BanditManager:
                     excluded_path_globs,
                     enforce_glob=False,
                 ):
+                    if fname != "-":
+                        fname = os.path.join(".", fname)
                     files_list.add(fname)
                 else:
                     excluded_files.add(fname)

--- a/tests/unit/core/test_manager.py
+++ b/tests/unit/core/test_manager.py
@@ -289,7 +289,7 @@ class ManagerTests(testtools.TestCase):
         self.manager.discover_files(
             ["a.py", "test_a.py", "test.py"], True, excluded_paths="test_*.py"
         )
-        self.assertEqual(["a.py", "test.py"], self.manager.files_list)
+        self.assertEqual(["./a.py", "./test.py"], self.manager.files_list)
         self.assertEqual(["test_a.py"], self.manager.excluded_files)
 
     @mock.patch("os.path.isdir")
@@ -298,7 +298,7 @@ class ManagerTests(testtools.TestCase):
         with mock.patch.object(manager, "_is_file_included") as m:
             m.return_value = True
             self.manager.discover_files(["thing"], True)
-            self.assertEqual(["thing"], self.manager.files_list)
+            self.assertEqual(["./thing"], self.manager.files_list)
             self.assertEqual([], self.manager.excluded_files)
 
     def test_run_tests_keyboardinterrupt(self):


### PR DESCRIPTION
The get_module_qualname_from_path() function called by the node visistor expects that all files are explicitly named with a "head" and "tail" which are path delimiters to denote where the file is within a python project.

However, if someone uses the command line and simply asks bandit to scan dummy.py in the current working directory, it will be missing the explicit "./" prefix in order for get_module_qualname_from_path to run and determine the module fully qualified name from the path.

So this fix simply prepends a dot and delimiter to explicitly denote a file in the current working directory as given from the CLI.

Fixes #907