### PR TITLE
Add random.randbytes to blacklist calls

### DIFF
--- a/bandit/blacklists/calls.py
+++ b/bandit/blacklists/calls.py
@@ -198,6 +198,7 @@ https://docs.python.org/library/secrets.html
 |      |                     | - random.choices                   |           |
 |      |                     | - random.uniform                   |           |
 |      |                     | - random.triangular                |           |
+|      |                     | - random.randbytes                 |           |
 +------+---------------------+------------------------------------+-----------+
 
 B312: telnetlib
@@ -523,6 +524,7 @@ def gen_blacklist():
                 "random.choices",
                 "random.uniform",
                 "random.triangular",
+                "random.randbytes",
             ],
             "Standard pseudo-random generators are not suitable for "
             "security/cryptographic purposes.",

--- a/examples/random_module.py
+++ b/examples/random_module.py
@@ -10,6 +10,7 @@ bad = random.choice()
 bad = random.choices()
 bad = random.uniform()
 bad = random.triangular()
+bad = random.randbytes()
 
 good = os.urandom()
 good = random.SystemRandom()

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -396,8 +396,8 @@ class FunctionalTests(testtools.TestCase):
     def test_random_module(self):
         """Test for the `random` module."""
         expect = {
-            "SEVERITY": {"UNDEFINED": 0, "LOW": 8, "MEDIUM": 0, "HIGH": 0},
-            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 8},
+            "SEVERITY": {"UNDEFINED": 0, "LOW": 9, "MEDIUM": 0, "HIGH": 0},
+            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 9},
         }
         self.check_example("random_module.py", expect)
 


### PR DESCRIPTION
In Python 3.9, the random module added new function randbytes(n). This function shouldn't be used for any cryptographic operations. As the doc recommends, use secrets.token_bytes() instead.

https://docs.python.org/3/library/random.html#random.randbytes