### PR TITLE
Rework GitPython dependency to be an extra for bandit-baseline

### DIFF
--- a/bandit/cli/baseline.py
+++ b/bandit/cli/baseline.py
@@ -19,7 +19,10 @@ import subprocess  # nosec: B404
 import sys
 import tempfile
 
-import git
+try:
+    import git
+except ImportError:
+    git = None
 
 bandit_args = sys.argv[1:]
 baseline_tmp_file = "_bandit_baseline_run.json_"
@@ -198,6 +201,11 @@ def initialize():
     report_fname = f"{report_basename}.{output_format}"
 
     # #################### Check Requirements #################################
+    if git is None:
+        LOG.error("Git not available, reinstall with baseline extra")
+        valid = False
+        return (None, None, None)
+
     try:
         repo = git.Repo(os.getcwd())
 

--- a/doc/source/start.rst
+++ b/doc/source/start.rst
@@ -31,6 +31,13 @@ If you want to include TOML support, install it with the `toml` extras:
 
     pip install bandit[toml]
 
+If you want to use the bandit-baseline CLI, install it with the `baseline`
+extras:
+
+.. code-block:: console
+
+    pip install bandit[baseline]
+
 Run Bandit:
 
 .. code-block:: console

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # The order of packages is significant, because pip processes them in the order
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
-GitPython>=3.1.30 # BSD License (3 clause)
 PyYAML>=5.3.1 # MIT
 stevedore>=1.20.0 # Apache-2.0
 colorama>=0.3.9;platform_system=="Windows" # BSD License (3 clause)

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,8 @@ yaml =
     PyYAML
 toml =
     tomli>=1.1.0; python_version < "3.11"
+baseline =
+    GitPython>=3.1.30
 
 [entry_points]
 console_scripts =

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,6 +7,5 @@ flake8>=4.0.0 # Apache-2.0
 stestr>=2.5.0 # Apache-2.0
 testscenarios>=0.5.0 # Apache-2.0/BSD
 testtools>=2.3.0 # MIT
-tomli>=1.1.0;python_version<"3.11" # MIT
 beautifulsoup4>=4.8.0 # MIT
 pylint==1.9.4 # GPLv2

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,10 @@ setenv =
 deps =
        -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
+extras =
+    yaml
+    toml
+    baseline
 commands =
     find bandit -type f -name "*.pyc" -delete
     stestr run {posargs}
@@ -34,7 +38,6 @@ commands = flake8 {posargs} bandit
            bandit-baseline -r bandit -ll -ii
 
 [testenv:pep8]
-skip_install = true
 ignore_errors = true
 deps = {[testenv]deps}
        .


### PR DESCRIPTION
The only piece of code that requires GitPython is bandit-baseline. There tends to be an abundance of CVEs in the GitPython library due to its dependency on Git. By making GitPython optional via an extra, users who mostly use just the bandit command line and not bandit-baseline can benefit.

However, this will require different install if a user wants to use bandit-baseline. This is now noted in the Getting Started doc, but you simply do:

```pip install bandit[GitPython]```

FYI, this option was suggested in PR #976.
