### PR TITLE
Remove markdown formatting in reStructuredText formatted README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,9 +90,9 @@ Container Images
 Bandit is available as a container image, built within the bandit repository
 using GitHub Actions. The image is available on ghcr.io:
 
-```bash
-docker pull ghcr.io/pycqa/bandit/bandit
-```
+.. code-block:: console
+
+    docker pull ghcr.io/pycqa/bandit/bandit
 
 The image is built for the following architectures:
 
@@ -103,17 +103,17 @@ The image is built for the following architectures:
 
 To pull a specific architecture, use the following format:
 
-```bash
-docker pull --platform=<architecture> ghcr.io/pycqa/bandit/bandit:latest
-```
+.. code-block:: console
+
+    docker pull --platform=<architecture> ghcr.io/pycqa/bandit/bandit:latest
 
 Every image is signed with sigstore cosign and it is possible to verify the
 source of origin using the following cosign command:
 
-```bash
-cosign verify ghcr.io/pycqa/bandit/bandit:py39-amd64 \
-  --certificate-identity https://github.com/pycqa/bandit/.github/workflows/build-publish-image.yml@refs/tags/<version> \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com
-```
+.. code-block:: console
+
+    cosign verify ghcr.io/pycqa/bandit/bandit:py39-amd64 \
+      --certificate-identity https://github.com/pycqa/bandit/.github/workflows/build-publish-image.yml@refs/tags/<version> \
+      --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 Where `<version>` is the release version of Bandit.


### PR DESCRIPTION
A recent change to the README has code blocks in markdown format. Since our README is actually reStructuredText format, this causes syntax errors.

It's even bigger of a problem when an attempt to publish the package with the README serving as the PyPI description. The syntax errors prevents package publishing.

Fixes #1102