### PR TITLE
Downsize the org:repo name

### DIFF
--- a/.github/workflows/build-publish-image.yml
+++ b/.github/workflows/build-publish-image.yml
@@ -45,6 +45,10 @@ jobs:
       with:
         cosign-release: 'v2.2.2'
 
+    - name: Downcase github.repository value
+      run: |
+        echo "IMAGE_NAME=`echo ${{github.repository}} | tr '[:upper:]' '[:lower:]'`" >>${GITHUB_ENV}
+
     - name: Build and push Docker image
       id: build-and-push
       uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5
@@ -52,12 +56,12 @@ jobs:
         context: .
         file: ./docker/Dockerfile
         push: true
-        tags: ghcr.io/${{ github.repository }}/bandit:latest
+        tags: ghcr.io/${{ env.IMAGE_NAME }}/bandit:latest
         platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/arm/v8
 
     - name: Sign the image
       env:
-        TAGS: ghcr.io/${{ github.repository }}/bandit:latest
+        TAGS: ghcr.io/${{ env.IMAGE_NAME }}/bandit:latest
         DIGEST: ${{ steps.build-and-push.outputs.digest }}
       run: |
         echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}


### PR DESCRIPTION
Currently we fail with:

`ERROR: invalid tag "ghcr.io/PyCQA/bandit/bandit:latest": repository name must be lowercase`

This is from the capitalized org name: PyCQA

This change lowercases the entire string