### PR TITLE
[B605] Add functions that are vulnerable to shell injection.

### DIFF
--- a/bandit/plugins/injection_shell.py
+++ b/bandit/plugins/injection_shell.py
@@ -49,6 +49,8 @@ def gen_config(name):
                 "popen2.Popen4",
                 "commands.getoutput",
                 "commands.getstatusoutput",
+                "subprocess.getoutput",
+                "subprocess.getstatusoutput",
             ],
             # Start a process with a function that is not vulnerable to shell
             # injection.
@@ -447,6 +449,8 @@ def start_process_with_a_shell(context, config):
                 - popen2.Popen4
                 - commands.getoutput
                 - commands.getstatusoutput
+                - subprocess.getoutput
+                - subprocess.getstatusoutput
 
     :Example:
 

--- a/examples/subprocess_shell.py
+++ b/examples/subprocess_shell.py
@@ -26,6 +26,9 @@ subprocess.check_call('/bin/ls -l', shell=True)
 subprocess.check_output(['/bin/ls', '-l'])
 subprocess.check_output('/bin/ls -l', shell=True)
 
+subprocess.getoutput('/bin/ls -l')
+subprocess.getstatusoutput('/bin/ls -l')
+
 subprocess.run(['/bin/ls', '-l'])
 subprocess.run('/bin/ls -l', shell=True)
 

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -493,8 +493,8 @@ class FunctionalTests(testtools.TestCase):
     def test_subprocess_shell(self):
         """Test for `subprocess.Popen` with `shell=True`."""
         expect = {
-            "SEVERITY": {"UNDEFINED": 0, "LOW": 21, "MEDIUM": 1, "HIGH": 11},
-            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 1, "MEDIUM": 0, "HIGH": 32},
+            "SEVERITY": {"UNDEFINED": 0, "LOW": 23, "MEDIUM": 1, "HIGH": 11},
+            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 1, "MEDIUM": 0, "HIGH": 34},
         }
         self.check_example("subprocess_shell.py", expect)
 


### PR DESCRIPTION
`subprocess.getstatusoutput()` will call `check_output(cmd, shell=True)` [source code](https://github.com/python/cpython/blob/22ccf13b332902142fe0c52c593f9efc152c7761/Lib/subprocess.py#L675), so I think extending the scan scope is proper.