### PR TITLE
update B405 rules

### DIFF
--- a/bandit/blacklists/imports.py
+++ b/bandit/blacklists/imports.py
@@ -74,7 +74,10 @@ or make sure defusedxml.defuse_stdlib() is called.
 | ID   |  Name               |  Imports                           |  Severity |
 +======+=====================+====================================+===========+
 | B405 | import_xml_etree    | - xml.etree.cElementTree           | low       |
-|      |                     | - xml.etree.ElementTree            |           |
+|      |                     | - xml.etree.ElementTree.XMLParser  |           |
+|      |                     | - xml.etree.ElementTree.fromstring |           |
+|      |                     | - xml.etree.ElementTree.iterparse  |           |
+|      |                     | - xml.etree.ElementTree.parse      |           |
 +------+---------------------+------------------------------------+-----------+
 
 B406: import_xml_sax
@@ -308,7 +311,13 @@ def gen_blacklist():
             "import_xml_etree",
             "B405",
             issue.Cwe.IMPROPER_INPUT_VALIDATION,
-            ["xml.etree.cElementTree", "xml.etree.ElementTree"],
+            [
+                "xml.etree.cElementTree",
+                "xml.etree.ElementTree.XMLParser",
+                "xml.etree.ElementTree.fromstring",
+                "xml.etree.ElementTree.iterparse",
+                "xml.etree.ElementTree.parse",
+            ],
             xml_msg,
             "LOW",
         )


### PR DESCRIPTION
make [B405](https://bandit.readthedocs.io/en/latest/blacklists/blacklist_imports.html#b405-import-xml-etree) rules more specific. Because not all in the module is related to parse xml. Some of them is needed for typing, for example `Element`. the reason why only the `ElementTree` module is updated is because defusedxml says [in its readme](https://github.com/tiran/defusedxml?tab=readme-ov-file#defusedxmlcelementtree) that `cElementTree` is deprecated.

This PR update the B405 rules, and make it more specific by add these `parse()`, `iterparse()`, `fromstring()`, `XMLParser`. 
This is necessary because the contents of the `ElementTree` module are not all related to parsing xml. Some of them are needed for typing, such as `Element`.

From the [docs](https://docs.python.org/3/library/xml.etree.elementtree.html) stated that there is more functions or classes that relates with parsing.  Here are some, but i may miss some.
- [fromstring()](https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.fromstring)
- [fromstringlist()](https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.fromstringlist)
- [iterparse()](https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.iterparse)
- [parse()](https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.parse)
- [XML](https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.XML)
- [XMLID](https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.XMLID)
- [XMLParser](https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.XMLParser)
- [XMLPullParser](https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.XMLPullParser)

The main reason why only these `parse()`, `iterparse()`, `fromstring()`, `XMLParser` that is included in B405 rules, because [defusedxml document it](https://github.com/tiran/defusedxml?tab=readme-ov-file#defusedxmlelementtree) and the [test example files](https://github.com/PyCQA/bandit/blob/main/examples/xml_etree_elementtree.py) test it. Maybe some functions or classes listed above could be included. So this PR will change the B405 rules which previously would give warnings about the entire contents of the `ElementTree` module, to just
- [fromstring()](https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.fromstring)
- [iterparse()](https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.iterparse)
- [parse()](https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.parse)
- [XMLParser](https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.XMLParser)

Issue: https://github.com/PyCQA/bandit/issues/709

Tagging people related on issue: @vanschelven @seanmceligot to find out what is missed in this PR.