### PR TITLE
Start testing on Python 3.13

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -52,6 +52,7 @@ jobs:
           ["3.10", "310"],
           ["3.11", "311"],
           ["3.12", "312"],
+          ["3.13.0-a - 3.13", "313"],
         ]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Python 3.13 is currently in alpha, but it's useful to have a test scenario to vet it early before it is released to flush out any Bandit issues as a result of a new runtime.

Note: the Python matrix change here uses a range so that it can continually test 3.13 alpha releases all the way to GA'd versions.