### PR TITLE
Add action to upload the wheel and tar-zipped distributions

### DIFF
--- a/.github/workflows/upload-asset.yml
+++ b/.github/workflows/upload-asset.yml
@@ -1,0 +1,46 @@
+name: Upload wheel asset
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build-n-publish:
+    name: Build and upload wheel as asset
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      attestations: write
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.8
+
+    - name: Install dependencies
+      run: pip install setuptools wheel
+
+    - name: Build a binary wheel and a source tarball
+      run: |
+        python setup.py sdist bdist_wheel
+
+    - name: Release
+      uses: softprops/action-gh-release@v2
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: |
+          dist/*.whl
+          dist/*.tar.gz
+
+    - name: Attest Build Provenance
+      uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940
+      with:
+        subject-path: 'dist/bandit-*'


### PR DESCRIPTION
We already publish to PyPI our packages. It is also useful to publish our binaries as artifacts here on GitHub. This action will build and publish release files as artifacts in the current release.

It runs whenever a new release is published.

This change also adds attestation of the artifacts so that users can verify the binary is the authentic one produced by our build.

More info on attestation here:
https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/