### PR TITLE
Ensure sarif extra is included as part of doc build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,3 +14,5 @@ python:
     - requirements: doc/requirements.txt
     - method: pip
       path: .
+      extra_requirements:
+        - sarif


### PR DESCRIPTION
The doc build nowadays runs via the readthedocs.yaml file. So the requirements for building those docs need to include sarif in order to correctly build the sarif formatter doc.

Fixes: #1138