### PR TITLE
Guard against empty call argument list

### DIFF
--- a/bandit/plugins/injection_shell.py
+++ b/bandit/plugins/injection_shell.py
@@ -683,7 +683,7 @@ def start_process_with_partial_path(context, config):
         ):
             node = context.node.args[0]
             # some calls take an arg list, check the first part
-            if isinstance(node, ast.List):
+            if isinstance(node, ast.List) and node.elts:
                 node = node.elts[0]
 
             # make sure the param is a string literal and not a var name

--- a/examples/subprocess_shell.py
+++ b/examples/subprocess_shell.py
@@ -25,6 +25,7 @@ subprocess.check_call('/bin/ls -l', shell=True)
 
 subprocess.check_output(['/bin/ls', '-l'])
 subprocess.check_output('/bin/ls -l', shell=True)
+subprocess.check_output([], stdout=None)
 
 subprocess.getoutput('/bin/ls -l')
 subprocess.getstatusoutput('/bin/ls -l')

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -492,8 +492,8 @@ class FunctionalTests(testtools.TestCase):
     def test_subprocess_shell(self):
         """Test for `subprocess.Popen` with `shell=True`."""
         expect = {
-            "SEVERITY": {"UNDEFINED": 0, "LOW": 23, "MEDIUM": 1, "HIGH": 11},
-            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 1, "MEDIUM": 0, "HIGH": 34},
+            "SEVERITY": {"UNDEFINED": 0, "LOW": 24, "MEDIUM": 1, "HIGH": 11},
+            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 1, "MEDIUM": 0, "HIGH": 35},
         }
         self.check_example("subprocess_shell.py", expect)
 


### PR DESCRIPTION
Although probably uncommon, it is possible to pass an empty list to one of subprocess functions. If this is done, the injection_shell plugin raises an IndexError while checking the contents of the list argument given.

The fix is to simply check for a non-empty list. Test case was also added.

Fixes: #1141