### PR TITLE
Performance improvement in blacklist function

### DIFF
--- a/bandit/blacklists/calls.py
+++ b/bandit/blacklists/calls.py
@@ -537,7 +537,7 @@ def gen_blacklist():
             "telnetlib",
             "B312",
             issue.Cwe.CLEARTEXT_TRANSMISSION,
-            ["telnetlib.*"],
+            ["telnetlib.Telnet"],
             "Telnet-related functions are being called. Telnet is considered "
             "insecure. Use SSH or some other encrypted protocol.",
             "HIGH",
@@ -662,7 +662,7 @@ def gen_blacklist():
             "ftplib",
             "B321",
             issue.Cwe.CLEARTEXT_TRANSMISSION,
-            ["ftplib.*"],
+            ["ftplib.FTP"],
             "FTP-related functions are being called. FTP is considered "
             "insecure. Use SSH/SFTP/SCP or some other encrypted protocol.",
             "HIGH",

--- a/bandit/core/blacklisting.py
+++ b/bandit/core/blacklisting.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import ast
-import fnmatch
 
 from bandit.core import issue
 
@@ -55,7 +54,7 @@ def blacklist(context, config):
                     name = context.call_keywords["name"]
         for check in blacklists[node_type]:
             for qn in check["qualnames"]:
-                if name is not None and fnmatch.fnmatch(name, qn):
+                if name is not None and name == qn:
                     return report_issue(check, name)
 
     if node_type.startswith("Import"):


### PR DESCRIPTION
The blacklisting function is currently using fnmatch.fnmatch() to do matching of qualified names of blacklist calls. It seems it is only used for telnetlib and ftplib where they are setting the qualified name in a file glob style (telnetlib.*).

This change would slightly break backward compatibility if there are any third-party plugins that use globbing in the qualified names for blacklisting. I think the likelyhood is small. I also think it is better to be more explicit in the qualified name patterns. In the case of ftplib, FTP is insecure, but FTP_TLS is not. So this already is resolving one false postive.

The other effect of this change is a slight boost to performance. When scanning cpython prior to this fix, it would take around 1 min. After the fix, closer to 50 seconds. So a nice little bump in speed.

Fixes: #438