### PR TITLE
Add test for usage of FTP_TLS

### DIFF
--- a/bandit/blacklists/calls.py
+++ b/bandit/blacklists/calls.py
@@ -537,7 +537,7 @@ def gen_blacklist():
             "telnetlib",
             "B312",
             issue.Cwe.CLEARTEXT_TRANSMISSION,
-            ["telnetlib.*"],
+            ["telnetlib.Telnet"],
             "Telnet-related functions are being called. Telnet is considered "
             "insecure. Use SSH or some other encrypted protocol.",
             "HIGH",
@@ -662,7 +662,7 @@ def gen_blacklist():
             "ftplib",
             "B321",
             issue.Cwe.CLEARTEXT_TRANSMISSION,
-            ["ftplib.*"],
+            ["ftplib.FTP"],
             "FTP-related functions are being called. FTP is considered "
             "insecure. Use SSH/SFTP/SCP or some other encrypted protocol.",
             "HIGH",

--- a/bandit/core/blacklisting.py
+++ b/bandit/core/blacklisting.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import ast
-import fnmatch
 
 from bandit.core import issue
 
@@ -55,7 +54,7 @@ def blacklist(context, config):
                     name = context.call_keywords["name"]
         for check in blacklists[node_type]:
             for qn in check["qualnames"]:
-                if name is not None and fnmatch.fnmatch(name, qn):
+                if name is not None and name == qn:
                     return report_issue(check, name)
 
     if node_type.startswith("Import"):

--- a/examples/ftplib.py
+++ b/examples/ftplib.py
@@ -1,9 +1,24 @@
 from ftplib import FTP
+from ftplib import FTP_TLS
 
+
+# bad
 ftp = FTP('ftp.debian.org')
 ftp.login()
 
 ftp.cwd('debian')
 ftp.retrlines('LIST')
+
+ftp.quit()
+
+# okay
+ftp = ftplib.FTP_TLS(
+    "ftp.us.debian.org",
+    context=ssl.create_default_context(),
+)
+ftp.login()
+
+ftp.cwd("debian")
+ftp.retrlines("LIST")
 
 ftp.quit()

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -246,8 +246,8 @@ class FunctionalTests(testtools.TestCase):
     def test_ftp_usage(self):
         """Test for `import ftplib` and FTP.* calls."""
         expect = {
-            "SEVERITY": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 2},
-            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 2},
+            "SEVERITY": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 3},
+            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 3},
         }
         self.check_example("ftplib.py", expect)
 


### PR DESCRIPTION
This change adds an FTP_TLS call to the examples. A high severity
error is no longer reported as a result of the fix in PR #1148
that explicitly now matches blacklist call qualified names rather
than using a file glob.
    
However, you will notice that there is one more high severity
issue reported in the tests as a result of the import of
ftplib.FTP_TLS because the blacklist import is only checking for
"ftplib".
    
Fixes: #148
    
Signed-off-by: Eric Brown <eric_wade_brown@yahoo.com>