### PR TITLE
Removal of Python 3.8 support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -44,7 +44,8 @@ body:
       label: Bandit version
       description: Run "bandit --version" if unsure of version number
       options:
-        - 1.7.9 (Default)
+        - 1.7.10 (Default)
+        - 1.7.9
         - 1.7.8
         - 1.7.7
         - 1.7.6
@@ -63,11 +64,11 @@ body:
       label: Python version
       description: Run "bandit --version" if unsure of version number
       options:
-        - "3.12 (Default)"
+        - "3.13 (Default)"
+        - "3.12"
         - "3.11"
         - "3.10"
         - "3.9"
-        - "3.8"
     validations:
       required: true
 

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -13,10 +13,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install dependencies
       run: pip install wheel

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -13,10 +13,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install dependencies
       run: pip install wheel

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -47,7 +47,6 @@ jobs:
     strategy:
       matrix:
         python-version: [
-          ["3.8", "38"],
           ["3.9", "39"],
           ["3.10", "310"],
           ["3.11", "311"],

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.9"
 
 sphinx:
   configuration: doc/source/conf.py

--- a/bandit/blacklists/calls.py
+++ b/bandit/blacklists/calls.py
@@ -321,8 +321,6 @@ For further information:
 +------+---------------------+------------------------------------+-----------+
 
 """
-import sys
-
 from bandit.blacklists import utils
 from bandit.core import issue
 
@@ -373,52 +371,26 @@ def gen_blacklist():
         )
     )
 
-    if sys.version_info >= (3, 9):
-        sets.append(
-            utils.build_conf_dict(
-                "md5",
-                "B303",
-                issue.Cwe.BROKEN_CRYPTO,
-                [
-                    "Crypto.Hash.MD2.new",
-                    "Crypto.Hash.MD4.new",
-                    "Crypto.Hash.MD5.new",
-                    "Crypto.Hash.SHA.new",
-                    "Cryptodome.Hash.MD2.new",
-                    "Cryptodome.Hash.MD4.new",
-                    "Cryptodome.Hash.MD5.new",
-                    "Cryptodome.Hash.SHA.new",
-                    "cryptography.hazmat.primitives.hashes.MD5",
-                    "cryptography.hazmat.primitives.hashes.SHA1",
-                ],
-                "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
-            )
+    sets.append(
+        utils.build_conf_dict(
+            "md5",
+            "B303",
+            issue.Cwe.BROKEN_CRYPTO,
+            [
+                "Crypto.Hash.MD2.new",
+                "Crypto.Hash.MD4.new",
+                "Crypto.Hash.MD5.new",
+                "Crypto.Hash.SHA.new",
+                "Cryptodome.Hash.MD2.new",
+                "Cryptodome.Hash.MD4.new",
+                "Cryptodome.Hash.MD5.new",
+                "Cryptodome.Hash.SHA.new",
+                "cryptography.hazmat.primitives.hashes.MD5",
+                "cryptography.hazmat.primitives.hashes.SHA1",
+            ],
+            "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
         )
-    else:
-        sets.append(
-            utils.build_conf_dict(
-                "md5",
-                "B303",
-                issue.Cwe.BROKEN_CRYPTO,
-                [
-                    "hashlib.md4",
-                    "hashlib.md5",
-                    "hashlib.sha",
-                    "hashlib.sha1",
-                    "Crypto.Hash.MD2.new",
-                    "Crypto.Hash.MD4.new",
-                    "Crypto.Hash.MD5.new",
-                    "Crypto.Hash.SHA.new",
-                    "Cryptodome.Hash.MD2.new",
-                    "Cryptodome.Hash.MD4.new",
-                    "Cryptodome.Hash.MD5.new",
-                    "Cryptodome.Hash.SHA.new",
-                    "cryptography.hazmat.primitives.hashes.MD5",
-                    "cryptography.hazmat.primitives.hashes.SHA1",
-                ],
-                "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
-            )
-        )
+    )
 
     sets.append(
         utils.build_conf_dict(

--- a/bandit/plugins/hashlib_insecure_functions.py
+++ b/bandit/plugins/hashlib_insecure_functions.py
@@ -48,8 +48,6 @@ hash variants.
     Added check for the crypt module weak hashes
 
 """  # noqa: E501
-import sys
-
 import bandit
 from bandit.core import issue
 from bandit.core import test_properties as test
@@ -86,21 +84,6 @@ def _hashlib_func(context, func):
                 )
 
 
-def _hashlib_new(context, func):
-    if func == "new":
-        args = context.call_args
-        keywords = context.call_keywords
-        name = args[0] if args else keywords.get("name", None)
-        if isinstance(name, str) and name.lower() in WEAK_HASHES:
-            return bandit.Issue(
-                severity=bandit.MEDIUM,
-                confidence=bandit.HIGH,
-                cwe=issue.Cwe.BROKEN_CRYPTO,
-                text=f"Use of insecure {name.upper()} hash function.",
-                lineno=context.node.lineno,
-            )
-
-
 def _crypt_crypt(context, func):
     args = context.call_args
     keywords = context.call_keywords
@@ -135,10 +118,7 @@ def hashlib(context):
         func = qualname_list[-1]
 
         if "hashlib" in qualname_list:
-            if sys.version_info >= (3, 9):
-                return _hashlib_func(context, func)
-            else:
-                return _hashlib_new(context, func)
+            return _hashlib_func(context, func)
 
         elif "crypt" in qualname_list and func in ("crypt", "mksalt"):
             return _crypt_crypt(context, func)

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -5,10 +5,10 @@ Under Which Version of Python Should I Install Bandit?
 ------------------------------------------------------
 
 The answer to this question depends on the project(s) you will be running
-Bandit against. If your project is only compatible with Python 3.8, you
-should install Bandit to run under Python 3.8. If your project is only
-compatible with Python 3.9, then use 3.9 respectively. If your project supports
-both, you *could* run Bandit with both versions but you don't have to.
+Bandit against. If your project is only compatible with Python 3.9, you
+should install Bandit to run under Python 3.9. If your project is only
+compatible with Python 3.10, then use 3.10 respectively. If your project
+supports both, you *could* run Bandit with both versions but you don't have to.
 
 Bandit uses the `ast` module from Python's standard library in order to
 analyze your Python code. The `ast` module is only able to parse Python code

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifier =
     Operating System :: MacOS :: MacOS X
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11

--- a/setup.py
+++ b/setup.py
@@ -4,5 +4,5 @@
 import setuptools
 
 setuptools.setup(
-    python_requires=">=3.8", setup_requires=["pbr>=2.0.0"], pbr=True
+    python_requires=">=3.9", setup_requires=["pbr>=2.0.0"], pbr=True
 )

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import os
-import sys
 
 import testtools
 
@@ -107,36 +106,10 @@ class FunctionalTests(testtools.TestCase):
 
     def test_crypto_md5(self):
         """Test the `hashlib.md5` example."""
-        if sys.version_info >= (3, 9):
-            expect = {
-                "SEVERITY": {
-                    "UNDEFINED": 0,
-                    "LOW": 0,
-                    "MEDIUM": 16,
-                    "HIGH": 9,
-                },
-                "CONFIDENCE": {
-                    "UNDEFINED": 0,
-                    "LOW": 0,
-                    "MEDIUM": 0,
-                    "HIGH": 25,
-                },
-            }
-        else:
-            expect = {
-                "SEVERITY": {
-                    "UNDEFINED": 0,
-                    "LOW": 0,
-                    "MEDIUM": 22,
-                    "HIGH": 4,
-                },
-                "CONFIDENCE": {
-                    "UNDEFINED": 0,
-                    "LOW": 0,
-                    "MEDIUM": 0,
-                    "HIGH": 26,
-                },
-            }
+        expect = {
+            "SEVERITY": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 16, "HIGH": 9},
+            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 25},
+        }
         self.check_example("crypto-md5.py", expect)
 
     def test_ciphers(self):
@@ -197,26 +170,10 @@ class FunctionalTests(testtools.TestCase):
 
     def test_imports_aliases(self):
         """Test the `import X as Y` syntax."""
-        if sys.version_info >= (3, 9):
-            expect = {
-                "SEVERITY": {"UNDEFINED": 0, "LOW": 4, "MEDIUM": 1, "HIGH": 4},
-                "CONFIDENCE": {
-                    "UNDEFINED": 0,
-                    "LOW": 0,
-                    "MEDIUM": 0,
-                    "HIGH": 9,
-                },
-            }
-        else:
-            expect = {
-                "SEVERITY": {"UNDEFINED": 0, "LOW": 4, "MEDIUM": 5, "HIGH": 0},
-                "CONFIDENCE": {
-                    "UNDEFINED": 0,
-                    "LOW": 0,
-                    "MEDIUM": 0,
-                    "HIGH": 9,
-                },
-            }
+        expect = {
+            "SEVERITY": {"UNDEFINED": 0, "LOW": 4, "MEDIUM": 1, "HIGH": 4},
+            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 9},
+        }
         self.check_example("imports-aliases.py", expect)
 
     def test_imports_from(self):
@@ -855,36 +812,10 @@ class FunctionalTests(testtools.TestCase):
 
     def test_hashlib_new_insecure_functions(self):
         """Test insecure hash functions created by `hashlib.new`."""
-        if sys.version_info >= (3, 9):
-            expect = {
-                "SEVERITY": {
-                    "UNDEFINED": 0,
-                    "LOW": 0,
-                    "MEDIUM": 0,
-                    "HIGH": 9,
-                },
-                "CONFIDENCE": {
-                    "UNDEFINED": 0,
-                    "LOW": 0,
-                    "MEDIUM": 0,
-                    "HIGH": 9,
-                },
-            }
-        else:
-            expect = {
-                "SEVERITY": {
-                    "UNDEFINED": 0,
-                    "LOW": 0,
-                    "MEDIUM": 10,
-                    "HIGH": 0,
-                },
-                "CONFIDENCE": {
-                    "UNDEFINED": 0,
-                    "LOW": 0,
-                    "MEDIUM": 0,
-                    "HIGH": 10,
-                },
-            }
+        expect = {
+            "SEVERITY": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 9},
+            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 9},
+        }
         self.check_example("hashlib_new_insecure_functions.py", expect)
 
     def test_blacklist_pycrypto(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.2.0
-envlist = py38,pep8
+envlist = py39,pep8
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
As of October 1st, 2024, Python 3.8 becomes end-of-life. As such Bandit should also no longer support the version.

This commit will bump minimum version of support to Python 3.9 and remove any legacy 3.8 specific code.

This is a breaking change for those still using Python 3.8 and so the minor version will be bumped to 1.8.x for it.

Closes #1173