### PR TITLE
fix(requirements.txt): Pin rich package to fix ModuleNotFoundError error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@
 PyYAML>=5.3.1 # MIT
 stevedore>=1.20.0 # Apache-2.0
 colorama>=0.3.9;platform_system=="Windows" # BSD License (3 clause)
-rich # MIT
+rich<13.9.0 # MIT


### PR DESCRIPTION
This should fix https://github.com/PyCQA/bandit/issues/1179 and https://github.com/PyCQA/bandit/issues/1180 issues, since the problem relies in latest `rich` release. 