### PR TITLE
Add more insecure cryptography cipher algorithms

### DIFF
--- a/bandit/blacklists/calls.py
+++ b/bandit/blacklists/calls.py
@@ -96,6 +96,12 @@ as AES.
 |      |                     |   .ciphers.algorithms.Blowfish     |           |
 |      |                     | - cryptography.hazmat.primitives   |           |
 |      |                     |   .ciphers.algorithms.IDEA         |           |
+|      |                     | - cryptography.hazmat.primitives   |           |
+|      |                     |   .ciphers.algorithms.CAST5        |           |
+|      |                     | - cryptography.hazmat.primitives   |           |
+|      |                     |   .ciphers.algorithms.SEED         |           |
+|      |                     | - cryptography.hazmat.primitives   |           |
+|      |                     |   .ciphers.algorithms.TripleDES    |           |
 +------+---------------------+------------------------------------+-----------+
 | B305 | cipher_modes        | - cryptography.hazmat.primitives   | Medium    |
 |      |                     |   .ciphers.modes.ECB               |           |
@@ -438,7 +444,10 @@ def gen_blacklist():
                 "Cryptodome.Cipher.XOR.new",
                 "cryptography.hazmat.primitives.ciphers.algorithms.ARC4",
                 "cryptography.hazmat.primitives.ciphers.algorithms.Blowfish",
+                "cryptography.hazmat.primitives.ciphers.algorithms.CAST5",
                 "cryptography.hazmat.primitives.ciphers.algorithms.IDEA",
+                "cryptography.hazmat.primitives.ciphers.algorithms.SEED",
+                "cryptography.hazmat.primitives.ciphers.algorithms.TripleDES",
             ],
             "Use of insecure cipher {name}. Replace with a known secure"
             " cipher such as AES.",

--- a/examples/ciphers.py
+++ b/examples/ciphers.py
@@ -71,6 +71,18 @@ cipher = Cipher(algorithms.Blowfish(key), mode=None, backend=default_backend())
 encryptor = cipher.encryptor()
 ct = encryptor.update(b"a secret message")
 
+cipher = Cipher(algorithms.CAST5(key), mode=None, backend=default_backend())
+encryptor = cipher.encryptor()
+ct = encryptor.update(b"a secret message")
+
 cipher = Cipher(algorithms.IDEA(key), mode=None, backend=default_backend())
+encryptor = cipher.encryptor()
+ct = encryptor.update(b"a secret message")
+
+cipher = Cipher(algorithms.SEED(key), mode=None, backend=default_backend())
+encryptor = cipher.encryptor()
+ct = encryptor.update(b"a secret message")
+
+cipher = Cipher(algorithms.TripleDES(key), mode=None, backend=default_backend())
 encryptor = cipher.encryptor()
 ct = encryptor.update(b"a secret message")

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -142,8 +142,8 @@ class FunctionalTests(testtools.TestCase):
     def test_ciphers(self):
         """Test the `Crypto.Cipher` example."""
         expect = {
-            "SEVERITY": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 1, "HIGH": 21},
-            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 22},
+            "SEVERITY": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 1, "HIGH": 24},
+            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 25},
         }
         self.check_example("ciphers.py", expect)
 


### PR DESCRIPTION
The cryptography project has added a few more cipher algorithms to its list of insecure, out-dated, or deprecated, i.e. decrepit symmetric algorithms.

Namely, CAST5, SEED, and TripleDES were added. As a result, Bandit should also alert to usage of these ciphers.

https://cryptography.io/en/latest/hazmat/decrepit/