### PR TITLE
Update project urls with added links

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,9 +25,12 @@ classifier =
     Programming Language :: Python :: 3 :: Only
     Topic :: Security
 project_urls =
+    Documentation = https://bandit.readthedocs.io/
     Release Notes = https://github.com/PyCQA/bandit/releases
     Source Code = https://github.com/PyCQA/bandit
     Issue Tracker = https://github.com/PyCQA/bandit/issues
+    Discord = https://discord.gg/qYxpadCgkx
+    Sponsor = https://psfmember.org/civicrm/contribute/transact/?reset=1&id=42
 
 [extras]
 yaml =


### PR DESCRIPTION
The PyPI warehouse supports a number of custom links to display on the project page. Of interest to Bandit are the links to the docs, sponsors, and discord.

https://github.com/pypi/warehouse/blob/main/warehouse/templates/packaging/detail.html