### PR TITLE
Remove Sentry as a sponsor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,9 +137,4 @@ The development of Bandit is made possible by the following sponsors:
           :alt: Stacklok
           :width: 88
 
-     - .. image:: https://avatars.githubusercontent.com/u/1396951?s=70&v=4
-          :target: https://sentry.io/
-          :alt: Sentry
-          :width: 88
-
 If you also ❤️ Bandit, please consider sponsoring.


### PR DESCRIPTION
Sentry recently ended their sponsorship. Technically the sponsorship wasn't going specifically to the project anyway, but to a user (me). So this change updates the README to reflect this.