### PR TITLE
Update the bug template with latest bandit version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -44,7 +44,8 @@ body:
       label: Bandit version
       description: Run "bandit --version" if unsure of version number
       options:
-        - 1.7.10 (Default)
+        - 1.8.0 (Default)
+        - 1.7.10
         - 1.7.9
         - 1.7.8
         - 1.7.7


### PR DESCRIPTION
Since Bandit 1.8.0 was just released, the bug template should also have 1.8.0 in its list of choices.