### PR TITLE
Remove lxml (B320 & B410) from blacklist

### DIFF
--- a/bandit/blacklists/calls.py
+++ b/bandit/blacklists/calls.py
@@ -219,7 +219,7 @@ SSH or some other encrypted protocol.
 | B312 | telnetlib           | - telnetlib.\*                     | High      |
 +------+---------------------+------------------------------------+-----------+
 
-B313 - B320: XML
+B313 - B319: XML
 ----------------
 
 Most of this is based off of Christian Heimes' work on defusedxml:
@@ -255,6 +255,22 @@ to XML attacks. Methods should be replaced with their defusedxml equivalents.
 +------+---------------------+------------------------------------+-----------+
 | B319 | xml_bad_pulldom     | - xml.dom.pulldom.parse            | Medium    |
 |      |                     | - xml.dom.pulldom.parseString      |           |
++------+---------------------+------------------------------------+-----------+
+
+B320: xml_bad_etree
+-------------------
+
+The check for this call has been removed.
+
++------+---------------------+------------------------------------+-----------+
+| ID   |  Name               |  Calls                             |  Severity |
++======+=====================+====================================+===========+
+| B320 | xml_bad_etree       | - lxml.etree.parse                 | Medium    |
+|      |                     | - lxml.etree.fromstring            |           |
+|      |                     | - lxml.etree.RestrictedElement     |           |
+|      |                     | - lxml.etree.GlobalParserTLS       |           |
+|      |                     | - lxml.etree.getDefaultParser      |           |
+|      |                     | - lxml.etree.check_docinfo         |           |
 +------+---------------------+------------------------------------+-----------+
 
 B321: ftplib
@@ -607,6 +623,8 @@ def gen_blacklist():
             xml_msg,
         )
     )
+
+    # skipped B320 as the check for a call to lxml.etree has been removed
 
     # end of XML tests
 

--- a/bandit/blacklists/calls.py
+++ b/bandit/blacklists/calls.py
@@ -256,13 +256,6 @@ to XML attacks. Methods should be replaced with their defusedxml equivalents.
 | B319 | xml_bad_pulldom     | - xml.dom.pulldom.parse            | Medium    |
 |      |                     | - xml.dom.pulldom.parseString      |           |
 +------+---------------------+------------------------------------+-----------+
-| B320 | xml_bad_etree       | - lxml.etree.parse                 | Medium    |
-|      |                     | - lxml.etree.fromstring            |           |
-|      |                     | - lxml.etree.RestrictedElement     |           |
-|      |                     | - lxml.etree.GlobalParserTLS       |           |
-|      |                     | - lxml.etree.getDefaultParser      |           |
-|      |                     | - lxml.etree.check_docinfo         |           |
-+------+---------------------+------------------------------------+-----------+
 
 B321: ftplib
 ------------
@@ -612,27 +605,6 @@ def gen_blacklist():
             issue.Cwe.IMPROPER_INPUT_VALIDATION,
             ["xml.dom.pulldom.parse", "xml.dom.pulldom.parseString"],
             xml_msg,
-        )
-    )
-
-    sets.append(
-        utils.build_conf_dict(
-            "xml_bad_etree",
-            "B320",
-            issue.Cwe.IMPROPER_INPUT_VALIDATION,
-            [
-                "lxml.etree.parse",
-                "lxml.etree.fromstring",
-                "lxml.etree.RestrictedElement",
-                "lxml.etree.GlobalParserTLS",
-                "lxml.etree.getDefaultParser",
-                "lxml.etree.check_docinfo",
-            ],
-            (
-                "Using {name} to parse untrusted XML data is known to be "
-                "vulnerable to XML attacks. Replace {name} with its "
-                "defusedxml equivalent function."
-            ),
         )
     )
 

--- a/bandit/blacklists/imports.py
+++ b/bandit/blacklists/imports.py
@@ -130,18 +130,6 @@ or make sure defusedxml.defuse_stdlib() is called.
 | B409 | import_xml_pulldom  | - xml.dom.pulldom                  | low       |
 +------+---------------------+------------------------------------+-----------+
 
-B410: import_lxml
------------------
-
-Using various methods to parse untrusted XML data is known to be vulnerable to
-XML attacks. Replace vulnerable imports with the equivalent defusedxml package.
-
-+------+---------------------+------------------------------------+-----------+
-| ID   |  Name               |  Imports                           |  Severity |
-+======+=====================+====================================+===========+
-| B410 | import_lxml         | - lxml                             | low       |
-+------+---------------------+------------------------------------+-----------+
-
 B411: import_xmlrpclib
 ----------------------
 
@@ -297,11 +285,6 @@ def gen_blacklist():
         "defusedxml package, or make sure defusedxml.defuse_stdlib() "
         "is called."
     )
-    lxml_msg = (
-        "Using {name} to parse untrusted XML data is known to be "
-        "vulnerable to XML attacks. Replace {name} with the "
-        "equivalent defusedxml package."
-    )
 
     sets.append(
         utils.build_conf_dict(
@@ -354,17 +337,6 @@ def gen_blacklist():
             issue.Cwe.IMPROPER_INPUT_VALIDATION,
             ["xml.dom.pulldom"],
             xml_msg,
-            "LOW",
-        )
-    )
-
-    sets.append(
-        utils.build_conf_dict(
-            "import_lxml",
-            "B410",
-            issue.Cwe.IMPROPER_INPUT_VALIDATION,
-            ["lxml"],
-            lxml_msg,
             "LOW",
         )
     )

--- a/bandit/blacklists/imports.py
+++ b/bandit/blacklists/imports.py
@@ -132,6 +132,7 @@ or make sure defusedxml.defuse_stdlib() is called.
 
 B410: import_lxml
 -----------------
+
 This import blacklist has been removed. The information here has been
 left for historical purposes.
 

--- a/bandit/blacklists/imports.py
+++ b/bandit/blacklists/imports.py
@@ -130,6 +130,20 @@ or make sure defusedxml.defuse_stdlib() is called.
 | B409 | import_xml_pulldom  | - xml.dom.pulldom                  | low       |
 +------+---------------------+------------------------------------+-----------+
 
+B410: import_lxml
+-----------------
+This import blacklist has been removed. The information here has been
+left for historical purposes.
+
+Using various methods to parse untrusted XML data is known to be vulnerable to
+XML attacks. Replace vulnerable imports with the equivalent defusedxml package.
+
++------+---------------------+------------------------------------+-----------+
+| ID   |  Name               |  Imports                           |  Severity |
++======+=====================+====================================+===========+
+| B410 | import_lxml         | - lxml                             | low       |
++------+---------------------+------------------------------------+-----------+
+
 B411: import_xmlrpclib
 ----------------------
 
@@ -340,6 +354,8 @@ def gen_blacklist():
             "LOW",
         )
     )
+
+    # skipped B410 as the check for import_lxml has been removed
 
     sets.append(
         utils.build_conf_dict(

--- a/examples/xml_lxml.py
+++ b/examples/xml_lxml.py
@@ -1,9 +1,0 @@
-import lxml.etree
-import lxml
-from lxml import etree
-from defusedxml.lxml import fromstring
-from defuxedxml import lxml as potatoe
-
-xmlString = "<note>\n<to>Tove</to>\n<from>Jani</from>\n<heading>Reminder</heading>\n<body>Don't forget me this weekend!</body>\n</note>"
-root = lxml.etree.fromstring(xmlString)
-root = fromstring(xmlString)

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -557,12 +557,6 @@ class FunctionalTests(testtools.TestCase):
         self.check_example("xml_expatbuilder.py", expect)
 
         expect = {
-            "SEVERITY": {"UNDEFINED": 0, "LOW": 3, "MEDIUM": 1, "HIGH": 0},
-            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 4},
-        }
-        self.check_example("xml_lxml.py", expect)
-
-        expect = {
             "SEVERITY": {"UNDEFINED": 0, "LOW": 2, "MEDIUM": 2, "HIGH": 0},
             "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 4},
         }


### PR DESCRIPTION
removes B320 (xml_bad_etree) and B410 (import_lxml)

fixes #767