### PR TITLE
Update bug template to include latest released versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -44,7 +44,9 @@ body:
       label: Bandit version
       description: Run "bandit --version" if unsure of version number
       options:
-        - 1.8.0 (Default)
+        - 1.8.2 (Default)
+        - 1.8.1
+        - 1.8.0
         - 1.7.10
         - 1.7.9
         - 1.7.8


### PR DESCRIPTION
The bug template should include a drop down selection for newly released Bandit versions 1.8.1 and 1.8.2.