### PR TITLE
Warn not error on an nonexistant test given

### DIFF
--- a/bandit/core/extension_loader.py
+++ b/bandit/core/extension_loader.py
@@ -1,10 +1,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
+import logging
 import sys
 
 from stevedore import extension
 
 from bandit.core import utils
+
+LOG = logging.getLogger(__name__)
 
 
 class Manager:
@@ -84,11 +87,11 @@ class Manager:
         """Validate that everything in the configured profiles looks good."""
         for inc in profile["include"]:
             if not self.check_id(inc):
-                raise ValueError(f"Unknown test found in profile: {inc}")
+                LOG.warning(f"Unknown test found in profile: {inc}")
 
         for exc in profile["exclude"]:
             if not self.check_id(exc):
-                raise ValueError(f"Unknown test found in profile: {exc}")
+                LOG.warning(f"Unknown test found in profile: {exc}")
 
         union = set(profile["include"]) & set(profile["exclude"])
         if len(union) > 0:

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -215,32 +215,8 @@ class BanditCLIMainTests(testtools.TestCase):
                 self.assertRaisesRegex(SystemExit, "2", bandit.main)
                 self.assertEqual(
                     str(err_mock.call_args[0][0]),
-                    "Unknown test found in profile: some_test",
+                    "No tests would be run, please check the profile.",
                 )
-
-    @mock.patch(
-        "sys.argv", ["bandit", "-c", "bandit.yaml", "-t", "badID", "test"]
-    )
-    def test_main_unknown_tests(self):
-        # Test that bandit exits when an invalid test ID is provided
-        temp_directory = self.useFixture(fixtures.TempDir()).path
-        os.chdir(temp_directory)
-        with open("bandit.yaml", "w") as fd:
-            fd.write(bandit_config_content)
-        # assert a SystemExit with code 2
-        self.assertRaisesRegex(SystemExit, "2", bandit.main)
-
-    @mock.patch(
-        "sys.argv", ["bandit", "-c", "bandit.yaml", "-s", "badID", "test"]
-    )
-    def test_main_unknown_skip_tests(self):
-        # Test that bandit exits when an invalid test ID is provided to skip
-        temp_directory = self.useFixture(fixtures.TempDir()).path
-        os.chdir(temp_directory)
-        with open("bandit.yaml", "w") as fd:
-            fd.write(bandit_config_content)
-        # assert a SystemExit with code 2
-        self.assertRaisesRegex(SystemExit, "2", bandit.main)
 
     @mock.patch(
         "sys.argv", ["bandit", "-c", "bandit.yaml", "-p", "bad", "test"]


### PR DESCRIPTION
When a user gives a test ID to include or skip, the current behavior raises an exception and exits the process.

However, when tests end up getting deprecated and eventually removed, it is a lot more user friendly to simple present a warning to the user that the test ID given wasn't found rather than a hard error and exit.

Fixes: #1228, #1226