### PR TITLE
B107: Skip None values in hardcoded password detection

### DIFF
--- a/bandit/plugins/general_hardcoded_password.py
+++ b/bandit/plugins/general_hardcoded_password.py
@@ -201,7 +201,9 @@ def hardcoded_password_default(context):
     - "token"
     - "secrete"
 
-    Note: this can be noisy and may generate false positives.
+    Note: this can be noisy and may generate false positives.  We do not
+    report on None values which can be legitimately used as a default value,
+    when initializing a function or class.
 
     **Config Options:**
 
@@ -242,5 +244,8 @@ def hardcoded_password_default(context):
     # go through all (param, value)s and look for candidates
     for key, val in zip(context.node.args.args, defs):
         if isinstance(key, (ast.Name, ast.arg)):
+            # Skip if the default value is None
+            if val is None or (isinstance(val, (ast.Constant, ast.NameConstant)) and val.value is None):
+                continue
             if isinstance(val, ast.Str) and RE_CANDIDATES.search(key.arg):
                 return _report(val.s)

--- a/bandit/plugins/general_hardcoded_password.py
+++ b/bandit/plugins/general_hardcoded_password.py
@@ -245,7 +245,10 @@ def hardcoded_password_default(context):
     for key, val in zip(context.node.args.args, defs):
         if isinstance(key, (ast.Name, ast.arg)):
             # Skip if the default value is None
-            if val is None or (isinstance(val, (ast.Constant, ast.NameConstant)) and val.value is None):
+            if val is None or (
+                isinstance(val, (ast.Constant, ast.NameConstant))
+                and val.value is None
+            ):
                 continue
             if isinstance(val, ast.Str) and RE_CANDIDATES.search(key.arg):
                 return _report(val.s)

--- a/examples/hardcoded-passwords.py
+++ b/examples/hardcoded-passwords.py
@@ -51,7 +51,7 @@ password = "blerg"
 
 # Possible hardcoded password: 'blerg'
 # Severity: Low   Confidence: Medium
-d["password"] = "blerg"
+password["password"] = "blerg"
 
 # Possible hardcoded password: 'secret'
 # Severity: Low   Confidence: Medium
@@ -68,3 +68,13 @@ my_secret_password_for_email = 'd6s$f9g!j8mg7hw?n&2'
 # Possible hardcoded password: '1234'
 # Severity: Low   Confidence: Medium
 passphrase='1234'
+
+# Possible hardcoded password: None
+# Severity: High   Confidence: High
+def __init__(self, auth_scheme, auth_token=None, auth_username=None, auth_password=None, auth_link=None, **kwargs):
+    self.auth_scheme = auth_scheme
+    self.auth_token = auth_token
+    self.auth_username = auth_username
+    self.auth_password = auth_password
+    self.auth_link = auth_link
+    self.kwargs = kwargs


### PR DESCRIPTION
The B107 check was incorrectly flagging None default values as hardcoded passwords in function definitions. This is a false positive since None is a legitimate and commonly used within __init__ initialization

This change modifies the hardcoded_password_default function to:
- Skip None values in parameter defaults
- Handle both ast.Constant (Python 3.8+) and ast.NameConstant (Python 3.7-) representations of None
- Update documentation to clarify None handling behavior

Example of code that no longer triggers B107:
def __init__(self, auth_scheme, auth_password=None):
    pass

Fixes: #1227