### PR TITLE
Metadata: rename classifier to classifiers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ author = PyCQA
 author_email = code-quality@python.org
 home_page = https://bandit.readthedocs.io/
 license = Apache-2.0 license
-classifier =
+classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Console
     Intended Audience :: Information Technology


### PR DESCRIPTION
Not sure if this metadata object changed names over time but some tooling such as LicenseCheck trips up if it's defined as classifier and not classifiers. 

This matches current documentation where it states classifier is an alias of classifiers according to metadata table here: https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#metadata

A separate issue was opened on LicenseCheck.