### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within setup.cfg
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,9 @@ repos:
 #    hooks:
 #    -   id: mypy
 #        exclude: ^(docs/|example-plugin/)
+
+- repo: https://github.com/codespell-project/codespell
+  # Configuration for codespell is in setup.cfg
+  rev: v2.4.1
+  hooks:
+  - id: codespell

--- a/bandit/cli/main.py
+++ b/bandit/cli/main.py
@@ -93,10 +93,10 @@ def _log_option_source(default_val, arg_val, ini_val, option_name):
             return ini_val
         else:
             return None
-    # No value passed to commad line and default value is used
+    # No value passed to command line and default value is used
     elif default_val == arg_val:
         return ini_val if ini_val else arg_val
-    # Certainly a value is passed to commad line
+    # Certainly a value is passed to command line
     else:
         return arg_val
 

--- a/bandit/core/manager.py
+++ b/bandit/core/manager.py
@@ -204,7 +204,7 @@ class BanditManager:
         :param recursive: True/False - whether to add all files from dirs
         :return:
         """
-        # We'll mantain a list of files which are added, and ones which have
+        # We'll maintain a list of files which are added, and ones which have
         # been explicitly excluded
         files_list = set()
         excluded_files = set()

--- a/bandit/plugins/injection_shell.py
+++ b/bandit/plugins/injection_shell.py
@@ -10,7 +10,7 @@ from bandit.core import issue
 from bandit.core import test_properties as test
 
 # yuck, regex: starts with a windows drive letter (eg C:)
-# or one of our path delimeter characters (/, \, .)
+# or one of our path delimiter characters (/, \, .)
 full_path_match = re.compile(r"^(?:[A-Za-z](?=\:)|[\\\/\.])")
 
 

--- a/examples/hashlib_new_insecure_functions.py
+++ b/examples/hashlib_new_insecure_functions.py
@@ -16,7 +16,7 @@ hashlib.new('sha', data=b'test')
 
 hashlib.new(name='SHA', data=b'test')
 
-# usedforsecurity arg only availabe in Python 3.9+
+# usedforsecurity arg only available in Python 3.9+
 hashlib.new('sha1', usedforsecurity=True)
 
 # Test that plugin does not flag valid hash functions.
@@ -24,5 +24,5 @@ hashlib.new('sha256')
 
 hashlib.new('SHA512')
 
-# usedforsecurity arg only availabe in Python 3.9+
+# usedforsecurity arg only available in Python 3.9+
 hashlib.new(name='sha1', usedforsecurity=False)

--- a/pylintrc
+++ b/pylintrc
@@ -15,7 +15,7 @@
 # C0116: Missing function or method docstring
 # C0201: consider-iterating-dictionary
 # C0206: Consider iterating with .items()
-# C0209: Foramtting a regular string which could be an f-string
+# C0209: Formatting a regular string which could be an f-string
 # C0413: wrong-import-position
 # C0415: Import outside toplevel
 # C1802: Do not use `len(SEQUENCE)` without comparison to determine if a sequence is empty

--- a/setup.cfg
+++ b/setup.cfg
@@ -176,7 +176,7 @@ autodoc_tree_excludes =
 
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git*,*.svg
+skip = .git*,*.svg,b109_password_config_option_not_marked_secret.rst,trojansource_latin1.py
 check-hidden = true
 # ignore-regex = 
-# ignore-words-list =
+# ignore-words-list = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -173,3 +173,10 @@ source-dir = doc/source
 autodoc_tree_index_modules = True
 autodoc_tree_excludes =
   examples*
+
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,*.svg
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/tests/unit/core/test_test_set.py
+++ b/tests/unit/core/test_test_set.py
@@ -139,7 +139,7 @@ class BanditTestSetTests(testtools.TestCase):
         profile = {"exclude": ["B401", "B302"]}
         ts = test_set.BanditTestSet(self.config, profile)
 
-        # if there is no blacklist data for a node type then we wont add a
+        # if there is no blacklist data for a node type then we won't add a
         # blacklist test to it, as this would be pointless.
         self.assertEqual(0, len(ts.get_tests("Import")))
         self.assertEqual(0, len(ts.get_tests("ImportFrom")))

--- a/tests/unit/core/test_util.py
+++ b/tests/unit/core/test_util.py
@@ -31,7 +31,7 @@ class UtilTests(testtools.TestCase):
 
         Create temporary directory and then create fake .py files
         within directory structure.  We setup test cases for
-        a typical module, a path misssing a middle __init__.py,
+        a typical module, a path missing a middle __init__.py,
         no __init__.py anywhere in path, symlinking .py files.
         """
 

--- a/tests/unit/core/test_util.py
+++ b/tests/unit/core/test_util.py
@@ -263,7 +263,7 @@ class UtilTests(testtools.TestCase):
     def test_linerange(self):
         with open("./examples/jinja2_templating.py") as test_file:
             tree = ast.parse(test_file.read())
-        # Check linerange returns corrent number of lines
+        # Check linerange returns current number of lines
         line = tree.body[8]
         lrange = b_utils.linerange(line)
 

--- a/tests/unit/formatters/test_json.py
+++ b/tests/unit/formatters/test_json.py
@@ -48,7 +48,7 @@ class JsonFormatterTests(testtools.TestCase):
                 bandit.HIGH,
                 issue.Cwe.MULTIPLE_BINDS,
                 bandit.HIGH,
-                "Candiate B",
+                "Candidate B",
                 lineno=2,
             ),
         ]

--- a/tests/unit/formatters/test_sarif.py
+++ b/tests/unit/formatters/test_sarif.py
@@ -52,7 +52,7 @@ class SarifFormatterTests(testtools.TestCase):
                 bandit.HIGH,
                 issue.Cwe.MULTIPLE_BINDS,
                 bandit.HIGH,
-                "Candiate B",
+                "Candidate B",
                 lineno=2,
             ),
         ]

--- a/tests/unit/formatters/test_yaml.py
+++ b/tests/unit/formatters/test_yaml.py
@@ -38,7 +38,7 @@ class YamlFormatterTests(testtools.TestCase):
 
         self.candidates = [
             issue.Issue(bandit.LOW, 123, bandit.LOW, "Candidate A", lineno=1),
-            issue.Issue(bandit.HIGH, 123, bandit.HIGH, "Candiate B", lineno=2),
+            issue.Issue(bandit.HIGH, 123, bandit.HIGH, "Candidate B", lineno=2),
         ]
 
         self.manager.out_file = self.tmp_fname


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.