### PR TITLE
Fix traceback from trojansource plugin

### DIFF
--- a/bandit/core/tester.py
+++ b/bandit/core/tester.py
@@ -65,7 +65,8 @@ class BanditTester:
 
                     if result.lineno is None:
                         result.lineno = temp_context["lineno"]
-                    result.linerange = temp_context["linerange"]
+                    if result.linerange == []:
+                        result.linerange = temp_context["linerange"]
                     if result.col_offset == -1:
                         result.col_offset = temp_context["col_offset"]
                     result.end_col_offset = temp_context.get(

--- a/bandit/plugins/trojansource.py
+++ b/bandit/plugins/trojansource.py
@@ -67,7 +67,7 @@ def trojansource(context):
                     "A Python source file contains bidirectional"
                     " control characters (%r)." % char
                 )
-                return bandit.Issue(
+                b_issue = bandit.Issue(
                     severity=bandit.HIGH,
                     confidence=bandit.MEDIUM,
                     cwe=issue.Cwe.INAPPROPRIATE_ENCODING_FOR_OUTPUT_CONTEXT,
@@ -75,3 +75,5 @@ def trojansource(context):
                     lineno=lineno,
                     col_offset=col_offset,
                 )
+                b_issue.linerange = [lineno]
+                return b_issue


### PR DESCRIPTION
The trojansource plugin functions differently where it doesn't process a file by AST node. It instead does a line by line search for suspicious characters.

As a result, it can't rely on the linerange being automatically set based on values fetched from the node. So it needs to set the linerange manually.

Fixes: #1246