### PR TITLE
Add a doc describing various integrations

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -13,6 +13,7 @@ Using and Extending Bandit
 
    start
    config
+   integrations
    plugins/index
    blacklists/index
    formatters/index

--- a/doc/source/integrations.rst
+++ b/doc/source/integrations.rst
@@ -1,0 +1,61 @@
+Integrations
+============
+
+Bandit can be integrated into a wide variety of developer tools, editors,
+CI/CD systems, and code quality pipelines. This page outlines popular
+integrations to help you seamlessly incorporate Bandit into your development
+workflow.
+
+IDE Integrations
+----------------
+
+.. list-table::
+   :widths: 30 70
+
+   * - Visual Studio Code
+     - `Bandit by PyCQA <https://marketplace.visualstudio.com/items?itemName=pycqa.bandit-pycqa>`_
+   * - Sublime Text
+     - `SublimeLinter-bandit <https://github.com/SublimeLinter/SublimeLinter-bandit>`_
+   * - Vim/Neovim
+     - `Asynchronous Lint Engine <https://github.com/dense-analysis/ale>`_
+   * - Emacs
+     - `flycheck-pycheckers <https://github.com/msherry/flycheck-pycheckers>`_
+
+CI/CD Integrations
+------------------
+
+.. list-table::
+   :widths: 30 70
+
+   * - GitHub Action
+     - `Bandit by PyCQA <https://github.com/marketplace/actions/bandit-by-pycqa>`_
+   * - Hudson/Jenkins
+     - `Bandit Plugin <https://github.com/mewz/bandit-plugin->`_
+
+Linters
+-------
+
+.. list-table::
+   :widths: 30 70
+
+   * - Ruff
+     - `flake8-bandit (S) <https://docs.astral.sh/ruff/rules/#flake8-bandit-s>`_
+   * - Flake8
+     - `flake8-bandit <https://github.com/tylerwince/flake8-bandit>`_
+
+Packages
+--------
+
+.. list-table::
+   :widths: 30 70
+
+   * - Ubuntu
+     - `bandit <https://packages.ubuntu.com/search?keywords=bandit&searchon=names&section=all>`_
+   * - Homebrew
+     - `bandit <https://formulae.brew.sh/formula/bandit>`_
+
+
+🙌 Contributions Welcome
+
+If you’ve integrated Bandit into another platform or tool, feel free to open
+a PR and update this page!


### PR DESCRIPTION
New doc to advise users of Bandit of the various integrations available to them. The list is probably missing some, but can be updated with time.

It currently only includes subsections for IDEs, CI/CDs, Linters, and Packages. But that can also be expanded with time.