### PR TITLE
Ensure the man page is built

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -21,6 +21,12 @@ jobs:
     - name: Install dependencies
       run: pip install wheel
 
+    - name: Build man page if not present
+      run: |
+        if [ ! -f doc/build/man/bandit.1 ]; then
+          tox run -e manpage
+        fi
+
     - name: Build a binary wheel and a source tarball
       run: |
         python setup.py sdist bdist_wheel

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -21,6 +21,12 @@ jobs:
     - name: Install dependencies
       run: pip install wheel
 
+    - name: Build man page if not present
+      run: |
+        if [ ! -f doc/build/man/bandit.1 ]; then
+          tox run -e manpage
+        fi
+
     - name: Build a binary wheel and a source tarball
       run: |
         python setup.py sdist bdist_wheel

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,20 @@
 # Copyright (c) 2013 Hewlett-Packard Development Company, L.P.
 #
 # SPDX-License-Identifier: Apache-2.0
+import os
+
 import setuptools
 
+
+data_files = []
+man_path = "doc/build/man/bandit.1"
+if os.path.isfile(man_path):
+    data_files.append(("share/man/man1", [man_path]))
+
+
 setuptools.setup(
-    python_requires=">=3.9", setup_requires=["pbr>=2.0.0"], pbr=True
+    python_requires=">=3.9",
+    setup_requires=["pbr>=2.0.0"],
+    pbr=True,
+    data_files=data_files,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -68,6 +68,11 @@ deps = -r{toxinidir}/doc/requirements.txt
 commands=
     sphinx-build doc/source doc/build
 
+[testenv:manpage]
+deps = -r{toxinidir}/doc/requirements.txt
+commands=
+    sphinx-build -b man doc/source doc/build/man
+
 [flake8]
 # [H106] Don't put vim configuration in source files.
 # [H203] Use assertIs(Not)None to check for None.


### PR DESCRIPTION
Ever since Sphinx switched to sphinx-build command to build docs, the man page was no longer being built. This is because there is now a separate subcommand "sphinx-build -b man" to generate the man page file.

This change adds the separate command and ensures our publish workflows generate the file when releasing a new bandit version.

This also adds the man page as part of the data files so it gets included with the wheel and is installed to share/man/man1.