### PR TITLE
Fix up some of the warnings when building docs

### DIFF
--- a/bandit/plugins/jinja2_templates.py
+++ b/bandit/plugins/jinja2_templates.py
@@ -51,7 +51,7 @@ false. A HIGH severity warning is generated in either of these scenarios.
 
 .. seealso::
 
- - `OWASP XSS <https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)>`_
+ - `OWASP XSS <https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)>`__
  - https://realpython.com/primer-on-jinja-templating/
  - https://jinja.palletsprojects.com/en/2.11.x/api/#autoescaping
  - https://security.openstack.org/guidelines/dg_cross-site-scripting-xss.html

--- a/bandit/plugins/mako_templates.py
+++ b/bandit/plugins/mako_templates.py
@@ -32,7 +32,7 @@ attacks.
 .. seealso::
 
  - https://www.makotemplates.org/
- - `OWASP XSS <https://owasp.org/www-community/attacks/xss/>`_
+ - `OWASP XSS <https://owasp.org/www-community/attacks/xss/>`__
  - https://security.openstack.org/guidelines/dg_cross-site-scripting-xss.html
  - https://cwe.mitre.org/data/definitions/80.html
 

--- a/bandit/plugins/pytorch_load.py
+++ b/bandit/plugins/pytorch_load.py
@@ -9,6 +9,7 @@ B614: Test for unsafe PyTorch load
 This plugin checks for unsafe use of `torch.load`. Using `torch.load` with
 untrusted data can lead to arbitrary code execution. There are two safe
 alternatives:
+
 1. Use `torch.load` with `weights_only=True` where only tensor data is
    extracted, and no arbitrary Python objects are deserialized
 2. Use the `safetensors` library from huggingface, which provides a safe

--- a/bandit/plugins/trojansource.py
+++ b/bandit/plugins/trojansource.py
@@ -24,8 +24,8 @@ to reorder source code characters in a way that changes its logic.
 
 .. seealso::
 
- .. https://trojansource.codes/
- .. https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42574
+ - https://trojansource.codes/
+ - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42574
 
 .. versionadded:: 1.7.10
 

--- a/bandit/plugins/trojansource.py
+++ b/bandit/plugins/trojansource.py
@@ -24,8 +24,8 @@ to reorder source code characters in a way that changes its logic.
 
 .. seealso::
 
- .. [1] https://trojansource.codes/
- .. [2] https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42574
+ .. https://trojansource.codes/
+ .. https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42574
 
 .. versionadded:: 1.7.10
 

--- a/doc/source/blacklists/blacklist_calls.rst
+++ b/doc/source/blacklists/blacklist_calls.rst
@@ -3,3 +3,4 @@ blacklist_calls
 ---------------
 
 .. automodule:: bandit.blacklists.calls
+   :no-index:

--- a/doc/source/blacklists/blacklist_imports.rst
+++ b/doc/source/blacklists/blacklist_imports.rst
@@ -3,3 +3,4 @@ blacklist_imports
 -----------------
 
 .. automodule:: bandit.blacklists.imports
+   :no-index:

--- a/doc/source/formatters/csv.rst
+++ b/doc/source/formatters/csv.rst
@@ -3,3 +3,4 @@ csv
 ---
 
 .. automodule:: bandit.formatters.csv
+   :no-index:

--- a/doc/source/formatters/custom.rst
+++ b/doc/source/formatters/custom.rst
@@ -3,3 +3,4 @@ custom
 ------
 
 .. automodule:: bandit.formatters.custom
+   :no-index:

--- a/doc/source/formatters/html.rst
+++ b/doc/source/formatters/html.rst
@@ -3,3 +3,4 @@ html
 ----
 
 .. automodule:: bandit.formatters.html
+   :no-index:

--- a/doc/source/formatters/json.rst
+++ b/doc/source/formatters/json.rst
@@ -3,3 +3,4 @@ json
 ----
 
 .. automodule:: bandit.formatters.json
+   :no-index:

--- a/doc/source/formatters/sarif.rst
+++ b/doc/source/formatters/sarif.rst
@@ -3,3 +3,4 @@ sarif
 -----
 
 .. automodule:: bandit.formatters.sarif
+   :no-index:

--- a/doc/source/formatters/screen.rst
+++ b/doc/source/formatters/screen.rst
@@ -3,3 +3,4 @@ screen
 ------
 
 .. automodule:: bandit.formatters.screen
+   :no-index:

--- a/doc/source/formatters/text.rst
+++ b/doc/source/formatters/text.rst
@@ -3,3 +3,4 @@ text
 ----
 
 .. automodule:: bandit.formatters.text
+   :no-index:

--- a/doc/source/formatters/xml.rst
+++ b/doc/source/formatters/xml.rst
@@ -3,3 +3,4 @@ xml
 ---
 
 .. automodule:: bandit.formatters.xml
+   :no-index:

--- a/doc/source/formatters/yaml.rst
+++ b/doc/source/formatters/yaml.rst
@@ -3,3 +3,4 @@ yaml
 ----
 
 .. automodule:: bandit.formatters.yaml
+   :no-index:

--- a/doc/source/plugins/b101_assert_used.rst
+++ b/doc/source/plugins/b101_assert_used.rst
@@ -3,3 +3,4 @@ B101: assert_used
 -----------------
 
 .. automodule:: bandit.plugins.asserts
+   :no-index:

--- a/doc/source/plugins/b102_exec_used.rst
+++ b/doc/source/plugins/b102_exec_used.rst
@@ -3,3 +3,4 @@ B102: exec_used
 ---------------
 
 .. automodule:: bandit.plugins.exec
+   :no-index:

--- a/doc/source/plugins/b103_set_bad_file_permissions.rst
+++ b/doc/source/plugins/b103_set_bad_file_permissions.rst
@@ -3,3 +3,4 @@ B103: set_bad_file_permissions
 ------------------------------
 
 .. automodule:: bandit.plugins.general_bad_file_permissions
+   :no-index:

--- a/doc/source/plugins/b104_hardcoded_bind_all_interfaces.rst
+++ b/doc/source/plugins/b104_hardcoded_bind_all_interfaces.rst
@@ -3,3 +3,4 @@ B104: hardcoded_bind_all_interfaces
 -----------------------------------
 
 .. automodule:: bandit.plugins.general_bind_all_interfaces
+   :no-index:

--- a/doc/source/plugins/b108_hardcoded_tmp_directory.rst
+++ b/doc/source/plugins/b108_hardcoded_tmp_directory.rst
@@ -3,3 +3,4 @@ B108: hardcoded_tmp_directory
 -----------------------------
 
 .. automodule:: bandit.plugins.general_hardcoded_tmp
+   :no-index:

--- a/doc/source/plugins/b110_try_except_pass.rst
+++ b/doc/source/plugins/b110_try_except_pass.rst
@@ -3,3 +3,4 @@ B110: try_except_pass
 ---------------------
 
 .. automodule:: bandit.plugins.try_except_pass
+   :no-index:

--- a/doc/source/plugins/b112_try_except_continue.rst
+++ b/doc/source/plugins/b112_try_except_continue.rst
@@ -3,3 +3,4 @@ B112: try_except_continue
 -------------------------
 
 .. automodule:: bandit.plugins.try_except_continue
+   :no-index:

--- a/doc/source/plugins/b113_request_without_timeout.rst
+++ b/doc/source/plugins/b113_request_without_timeout.rst
@@ -3,3 +3,4 @@ B113: request_without_timeout
 -----------------------------
 
 .. automodule:: bandit.plugins.request_without_timeout
+   :no-index:

--- a/doc/source/plugins/b201_flask_debug_true.rst
+++ b/doc/source/plugins/b201_flask_debug_true.rst
@@ -3,3 +3,4 @@ B201: flask_debug_true
 ----------------------
 
 .. automodule:: bandit.plugins.app_debug
+   :no-index:

--- a/doc/source/plugins/b202_tarfile_unsafe_members.rst
+++ b/doc/source/plugins/b202_tarfile_unsafe_members.rst
@@ -3,3 +3,4 @@ B202: tarfile_unsafe_members
 ----------------------------
 
 .. automodule:: bandit.plugins.tarfile_unsafe_members
+   :no-index:

--- a/doc/source/plugins/b324_hashlib.rst
+++ b/doc/source/plugins/b324_hashlib.rst
@@ -3,3 +3,4 @@ B324: hashlib
 -------------
 
 .. automodule:: bandit.plugins.hashlib_insecure_functions
+   :no-index:

--- a/doc/source/plugins/b501_request_with_no_cert_validation.rst
+++ b/doc/source/plugins/b501_request_with_no_cert_validation.rst
@@ -3,3 +3,4 @@ B501: request_with_no_cert_validation
 -------------------------------------
 
 .. automodule:: bandit.plugins.crypto_request_no_cert_validation
+   :no-index:

--- a/doc/source/plugins/b505_weak_cryptographic_key.rst
+++ b/doc/source/plugins/b505_weak_cryptographic_key.rst
@@ -3,3 +3,4 @@ B505: weak_cryptographic_key
 ----------------------------
 
 .. automodule:: bandit.plugins.weak_cryptographic_key
+   :no-index:

--- a/doc/source/plugins/b506_yaml_load.rst
+++ b/doc/source/plugins/b506_yaml_load.rst
@@ -3,3 +3,4 @@ B506: yaml_load
 ---------------
 
 .. automodule:: bandit.plugins.yaml_load
+   :no-index:

--- a/doc/source/plugins/b507_ssh_no_host_key_verification.rst
+++ b/doc/source/plugins/b507_ssh_no_host_key_verification.rst
@@ -3,3 +3,4 @@ B507: ssh_no_host_key_verification
 ----------------------------------
 
 .. automodule:: bandit.plugins.ssh_no_host_key_verification
+   :no-index:

--- a/doc/source/plugins/b601_paramiko_calls.rst
+++ b/doc/source/plugins/b601_paramiko_calls.rst
@@ -3,3 +3,4 @@ B601: paramiko_calls
 --------------------
 
 .. automodule:: bandit.plugins.injection_paramiko
+   :no-index:

--- a/doc/source/plugins/b608_hardcoded_sql_expressions.rst
+++ b/doc/source/plugins/b608_hardcoded_sql_expressions.rst
@@ -3,3 +3,4 @@ B608: hardcoded_sql_expressions
 -------------------------------
 
 .. automodule:: bandit.plugins.injection_sql
+   :no-index:

--- a/doc/source/plugins/b609_linux_commands_wildcard_injection.rst
+++ b/doc/source/plugins/b609_linux_commands_wildcard_injection.rst
@@ -3,3 +3,4 @@ B609: linux_commands_wildcard_injection
 ---------------------------------------
 
 .. automodule:: bandit.plugins.injection_wildcard
+   :no-index:

--- a/doc/source/plugins/b612_logging_config_insecure_listen.rst
+++ b/doc/source/plugins/b612_logging_config_insecure_listen.rst
@@ -3,3 +3,4 @@ B612: logging_config_insecure_listen
 ------------------------------------
 
 .. automodule:: bandit.plugins.logging_config_insecure_listen
+   :no-index:

--- a/doc/source/plugins/b613_trojansource.rst
+++ b/doc/source/plugins/b613_trojansource.rst
@@ -3,3 +3,4 @@ B613: trojansource
 ------------------
 
 .. automodule:: bandit.plugins.trojansource
+   :no-index:

--- a/doc/source/plugins/b614_pytorch_load.rst
+++ b/doc/source/plugins/b614_pytorch_load.rst
@@ -3,3 +3,4 @@ B614: pytorch_load
 ------------------
 
 .. automodule:: bandit.plugins.pytorch_load
+   :no-index:

--- a/doc/source/plugins/b701_jinja2_autoescape_false.rst
+++ b/doc/source/plugins/b701_jinja2_autoescape_false.rst
@@ -3,3 +3,4 @@ B701: jinja2_autoescape_false
 -----------------------------
 
 .. automodule:: bandit.plugins.jinja2_templates
+   :no-index:

--- a/doc/source/plugins/b702_use_of_mako_templates.rst
+++ b/doc/source/plugins/b702_use_of_mako_templates.rst
@@ -3,3 +3,4 @@ B702: use_of_mako_templates
 ---------------------------
 
 .. automodule:: bandit.plugins.mako_templates
+   :no-index:

--- a/doc/source/plugins/b704_markupsafe_markup_xss.rst
+++ b/doc/source/plugins/b704_markupsafe_markup_xss.rst
@@ -3,3 +3,4 @@ B704: markupsafe_markup_xss
 ---------------------------
 
 .. automodule:: bandit.plugins.markupsafe_markup_xss
+   :no-index:

--- a/doc/source/start.rst
+++ b/doc/source/start.rst
@@ -12,6 +12,7 @@ Create a virtual environment and activate it using `virtualenv` (optional):
 
     virtualenv bandit-env
     source bandit-env/bin/activate
+
 Alternatively, use `venv` instead of `virtualenv` (optional):
 
 .. code-block:: console


### PR DESCRIPTION
This change reduces the number of warnings out of Sphinx from 131 to 94. All of which are nit type fixes like spacing, indexing, etc.