### PR TITLE
Use license property in lieu of classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,14 +6,13 @@ description_file =
 author = PyCQA
 author_email = code-quality@python.org
 home_page = https://bandit.readthedocs.io/
-license = Apache-2.0 license
+license = Apache-2.0
 classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Console
     Intended Audience :: Information Technology
     Intended Audience :: System Administrators
     Intended Audience :: Developers
-    License :: OSI Approved :: Apache Software License
     Operating System :: POSIX :: Linux
     Operating System :: MacOS :: MacOS X
     Programming Language :: Python


### PR DESCRIPTION
When running `tox -e pep8` in the GitHub runner, a warning is displayed noting that the license classifier is deprecated.

```
× python setup.py bdist_wheel did not run successfully.

│ exit code: 1

╰─> [258 lines of output]

/home/runner/work/bandit/bandit/.tox/pep8/lib/python3.9/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

********************************************************************************

Please consider removing the following classifiers in favor of a SPDX license expression:

License :: OSI Approved :: Apache Software License
```

https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license