### PR TITLE
Use ubuntu latest for readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-lts-latest
   tools:
     python: "3.9"
 


### PR DESCRIPTION
Switch from ubuntu 22.04 to latest so we don't have to update this value to the latest version as new releases come out.