### PR TITLE
Remove etc from list of temp paths

### DIFF
--- a/bandit/plugins/general_hardcoded_tmp.py
+++ b/bandit/plugins/general_hardcoded_tmp.py
@@ -14,7 +14,6 @@ starting with (configurable) commonly used temporary paths, for example:
  - /tmp
  - /var/tmp
  - /dev/shm
- - etc
 
 **Config Options:**
 


### PR DESCRIPTION
In the docs for B108, it lists the configurable paths it checks for temp directory-like locations. In addition, it includes a bullet point for "etc". This might be misinterpretted as "/etc". I believe the original intention was to state etcetera, but might be confusing as listed.

This change just removes it from the list to get rid of any potential confusion.