### PR TITLE
Fix for publish to PyPI failure

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: 3.9
 
     - name: Install dependencies
-      run: pip install wheel
+      run: pip install tox wheel
 
     - name: Build man page if not present
       run: |

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: 3.9
 
     - name: Install dependencies
-      run: pip install wheel
+      run: pip install tox wheel
 
     - name: Build man page if not present
       run: |


### PR DESCRIPTION
This change fix the publishing step to PyPI and Test PyPI but ensuring that tox is installed.

This is a new issue to be fixed because previous releases never installed the man page.

Fixes: #1272