### PR TITLE
Fix the rendering of the CI/CD doc

### DIFF
--- a/doc/source/ci-cd/index.rst
+++ b/doc/source/ci-cd/index.rst
@@ -6,12 +6,14 @@ Continuous Integration and Deployment (CI/CD)
 This section provides documentation for setting up Continuous 
 Integration and Deployment (CI/CD) pipelines for automated 
 security scanning and quality assurance in this project.
+
 Supported CI/CD Platforms
 -------------------------  
 
 The following CI/CD platforms are covered:
 
 - **GitHub Actions**: Example workflows for security scanning and quality checks.
+
 Available Documentation
 -----------------------
 
@@ -19,6 +21,7 @@ Available Documentation
    :maxdepth: 1
 
    github-actions
+
 More CI/CD platforms and configurations may be added over time. 
 Contributions and improvements to these configurations are 
 welcome.


### PR DESCRIPTION
This change should fix the RST CICD file to properly render.

To see the broken output, look at:
https://bandit.readthedocs.io/en/latest/ci-cd/index.html