### PR TITLE
Add instructions for Maintainers to create/publish a release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ git clone https://github.com/<your username>/bandit.git
 
 Create you own branch to start writing code:
 ```shell script
-git checkout -b mybranch
+git switch -c mybranch
 <create local changes>
 git add <changed files>
 git commit -S

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,10 @@ git clone https://github.com/<your username>/bandit.git
 Create you own branch to start writing code:
 ```shell script
 git checkout -b mybranch
+<create local changes>
+git add <changed files>
+git commit -S
+<create a good commit message>
 git push origin mybranch
 ```
 You can test any changes with tox:
@@ -64,7 +68,8 @@ You can test any changes with tox:
 ```shell script
 pip install tox
 tox run -e pep8
-tox run -e py37
+tox run -e format
+tox run -e py39
 tox run -e docs
 tox run -e cover
 ```
@@ -245,3 +250,29 @@ To register your plugin, you have two options:
             bson = bandit_bson:formatter
         bandit.plugins =
             mako = bandit_mako
+
+## Creating and Publishing a Release (Maintainers)
+
+### Create the GitHub Release
+
+1. Navigate to the [Releases](https://github.com/PyCQA/bandit/releases) page
+2. Click on `Draft a new release`
+3. Under `Choose a tag` enter a new release version (typically increment the patch number) and select `Create new tag: <version> on publish`
+4. Click on `Generate release notes`
+5. Click on `Publish release`
+
+### Publish the Release to Test PyPI
+
+1. Go to `Actions` tab
+2. Click on the `Publish to Test PyPI` action
+3. Click on `Run workflow`
+4. Select `Use workflow from`, then `Tags` tab, and select `<version>`
+5. Click on `Run workflow`
+
+### Publish the Release to PyPI
+
+1. Go to `Actions` tab
+2. Click on the `Publish to PyPI` action
+3. Click on `Run workflow`
+4. Select `Use workflow from`, then `Tags` tab, and select `<version>`
+5. Click on `Run workflow`


### PR DESCRIPTION
This change adds steps to the Contributing document instructions to Maintainers on how to create and publish a release.

This change also fixed some missing steps in the git workflow and update of the Python version used to run unit tests with.