### PR TITLE
Set screen formatter colours based on terminal BG

### DIFF
--- a/bandit/formatters/screen.py
+++ b/bandit/formatters/screen.py
@@ -44,8 +44,9 @@ import sys
 import termios
 import time
 import tty
+from typing import Dict
+from typing import Union
 
-from typing import Union, Dict  # Tests use Python 3.7 (!) and 3.9
 from bandit.core import constants
 from bandit.core import docs_utils
 from bandit.core import test_properties


### PR DESCRIPTION
Two-stage background detection: $COLORFGBG followed by OSC11.
Fallback to dark if colour can't be detected using the methods above.
Can be overriden by $BANDIT_LIGHT_BG environment variable.

Resolves: #1271 

### Bright BG

![light_bg](https://github.com/user-attachments/assets/2aeddafd-7e4c-4fdb-ab43-107e40506b19)

### Dark BG

![dark_bg](https://github.com/user-attachments/assets/dc36ec29-b179-4261-a10c-d203873fec68)
