### PR TITLE
Check for revision hash on model / dataset download using hf hub

### DIFF
--- a/bandit/plugins/huggingface_unsafe_download.py
+++ b/bandit/plugins/huggingface_unsafe_download.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2024 PyCQA
+#
+# SPDX-License-Identifier: Apache-2.0
+r"""
+==================================================
+B615: Test for unsafe Hugging Face Hub downloads
+==================================================
+
+This plugin checks for unsafe downloads from Hugging Face Hub without proper
+integrity verification. Downloading models, datasets, or files without
+specifying a revision (commit hash, tag, or branch) can lead to supply chain
+attacks where malicious actors could replace model files.
+
+The secure approach is to:
+
+1. Pin to specific revisions/commits when downloading models or datasets
+2. Use authentication tokens for private repositories
+3. Verify file integrity when possible
+
+Common unsafe patterns:
+- ``AutoModel.from_pretrained("model-name")`` without revision
+- ``load_dataset("dataset-name")`` without revision
+- ``hf_hub_download()`` without revision parameter
+- ``snapshot_download()`` without revision parameter
+
+:Example:
+
+.. code-block:: none
+
+        >> Issue: Unsafe Hugging Face Hub download without revision pinning
+        Severity: Medium   Confidence: High
+        CWE: CWE-494 (https://cwe.mitre.org/data/definitions/494.html)
+        Location: examples/huggingface_unsafe_download.py:8
+        7    # Unsafe: no revision specified
+        8    model = AutoModel.from_pretrained("bert-base-uncased")
+        9
+
+.. seealso::
+
+     - https://cwe.mitre.org/data/definitions/494.html
+     - https://huggingface.co/docs/hub/security-best-practices
+     - https://huggingface.co/docs/huggingface_hub/guides/download
+
+.. versionadded:: 1.9.0
+
+"""
+import bandit
+from bandit.core import issue
+from bandit.core import test_properties as test
+
+
+@test.checks("Call")
+@test.test_id("B615")
+def huggingface_unsafe_download(context):
+    """
+    This plugin checks for unsafe downloads from Hugging Face Hub without
+    proper revision pinning. This can lead to supply chain vulnerabilities.
+    """
+    # Check if any HuggingFace-related modules are imported
+    hf_modules = [
+        "transformers",
+        "datasets",
+        "huggingface_hub",
+    ]
+
+    # Check if any HF modules are imported
+    hf_imported = any(
+        context.is_module_imported_like(module) for module in hf_modules
+    )
+
+    if not hf_imported:
+        return
+
+    qualname = context.call_function_name_qual
+    if not isinstance(qualname, str):
+        return
+
+    unsafe_patterns = {
+        # transformers library patterns
+        "from_pretrained": ["transformers"],
+        # datasets library patterns
+        "load_dataset": ["datasets"],
+        # huggingface_hub patterns
+        "hf_hub_download": ["huggingface_hub"],
+        "snapshot_download": ["huggingface_hub"],
+        "repository_id": ["huggingface_hub"],
+    }
+
+    qualname_parts = qualname.split(".")
+    func_name = qualname_parts[-1]
+
+    if func_name not in unsafe_patterns:
+        return
+
+    required_modules = unsafe_patterns[func_name]
+    if not any(module in qualname_parts for module in required_modules):
+        return
+
+    # Check for revision parameter (the key security control)
+    revision_specified = False
+
+    # Some different various ways revision can be specified
+    revision_params = ["revision", "commit_id", "use_auth_token"]
+    for param in revision_params:
+        if context.get_call_arg_value(param) is not None:
+            revision_specified = True
+            break
+
+    # Found one!
+    if revision_specified:
+        return
+
+    # Edge case: check if this is a local path (starts with ./ or /)
+    first_arg = context.get_call_arg_at_position(0)
+    if first_arg and isinstance(first_arg, str):
+        if first_arg.startswith(("./", "/", "../")):
+            # Local paths are generally safer
+            return
+
+    return bandit.Issue(
+        severity=bandit.MEDIUM,
+        confidence=bandit.HIGH,
+        text=(
+            f"Unsafe Hugging Face Hub download without revision pinning "
+            f"in {func_name}()"
+        ),
+        cwe=issue.Cwe.IMPROPER_INPUT_VALIDATION,
+        lineno=context.get_lineno_for_call_arg(func_name),
+    )

--- a/doc/source/plugins/b615_huggingface_unsafe_download.rst
+++ b/doc/source/plugins/b615_huggingface_unsafe_download.rst
@@ -1,0 +1,6 @@
+---------------------------------
+B615: huggingface_unsafe_download
+---------------------------------
+
+.. automodule:: bandit.plugins.huggingface_unsafe_download
+   :no-index:

--- a/examples/huggingface_unsafe_download.py
+++ b/examples/huggingface_unsafe_download.py
@@ -1,0 +1,69 @@
+from datasets import load_dataset
+from huggingface_hub import hf_hub_download, snapshot_download
+from transformers import AutoModel, AutoTokenizer
+
+# UNSAFE: These should trigger B615 warnings
+
+# Unsafe model loading without revision
+model = AutoModel.from_pretrained("bert-base-uncased")
+
+# Unsafe tokenizer loading without revision  
+tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
+
+# Unsafe dataset loading without revision
+dataset = load_dataset("imdb")
+
+# Unsafe file download without revision
+file_path = hf_hub_download(
+    repo_id="deepseek-ai/DeepSeek-R1",
+    filename="config.json"
+)
+
+# Unsafe snapshot download without revision
+snapshot_download(repo_id="meta-llama/Llama-3.1-8B-Instruct")
+
+# SAFE: These should NOT trigger warnings
+
+# Safe model loading with revision pinned
+safe_model = AutoModel.from_pretrained(
+    "deepseek-ai/DeepSeek-V3", 
+    revision="main"
+)
+
+# Safe model loading with commit hash
+safe_model_hash = AutoModel.from_pretrained(
+    "google-bert/bert-base-uncased",
+    revision="5d0f2e8a7f1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
+)
+
+# Safe tokenizer with revision
+safe_tokenizer = AutoTokenizer.from_pretrained(
+    "bert-base-uncased",
+    revision="v1.0"
+)
+
+# Safe dataset loading with revision
+safe_dataset = load_dataset("imdb", revision="main")
+
+# Safe file download with revision
+safe_file = hf_hub_download(
+    repo_id="microsoft/DialoGPT-medium",
+    filename="config.json",
+    revision="main"
+)
+
+# Safe snapshot download with revision
+snapshot_download(
+    repo_id="microsoft/DialoGPT-medium",
+    revision="v1.0"
+)
+
+# Safe: using authentication token (implies controlled access)
+auth_model = AutoModel.from_pretrained(
+    "private/model",
+    use_auth_token=True
+)
+
+# Safe: local path (not downloading from hub)
+local_model = AutoModel.from_pretrained("./local_model")
+local_model2 = AutoModel.from_pretrained("/path/to/model")

--- a/setup.cfg
+++ b/setup.cfg
@@ -157,6 +157,9 @@ bandit.plugins =
     #bandit/plugins/pytorch_load.py
     pytorch_load = bandit.plugins.pytorch_load:pytorch_load
 
+    # bandit/plugins/huggingface_unsafe_download.py
+    huggingface_unsafe_download = bandit.plugins.huggingface_unsafe_download:huggingface_unsafe_download
+
     # bandit/plugins/trojansource.py
     trojansource = bandit.plugins.trojansource:trojansource
 

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -926,3 +926,11 @@ class FunctionalTests(testtools.TestCase):
             self.check_example(
                 "markupsafe_markup_xss_allowed_calls.py", expect
             )
+
+    def test_huggingface_unsafe_download(self):
+        """Test for unsafe Hugging Face Hub downloads without revision pinning."""
+        expect = {
+            "SEVERITY": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 5, "HIGH": 0},
+            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 5},
+        }
+        self.check_example("huggingface_unsafe_download.py", expect)


### PR DESCRIPTION
In much the same way as unpinned container images benefit from digest pinning, fixing a model to a revision digest uniquely and immutably fixes use to a paricular model snapshot and provides a reproducability

The same also applies to datasets.