### PR TITLE
Huggingface revision pinning

### DIFF
--- a/bandit/plugins/huggingface_unsafe_download.py
+++ b/bandit/plugins/huggingface_unsafe_download.py
@@ -18,10 +18,22 @@ The secure approach is to:
 1. Pin to specific revisions/commits when downloading models, files or datasets
 
 Common unsafe patterns:
-- ``AutoModel.from_pretrained("model-name")`` without revision
-- ``load_dataset("dataset-name")`` without revision
-- ``hf_hub_download()`` without revision parameter
-- ``snapshot_download()`` without revision parameter
+- ``AutoModel.from_pretrained("org/model-name")``
+- ``AutoModel.from_pretrained("org/model-name", revision="main")``
+- ``AutoModel.from_pretrained("org/model-name", revision="v1.0.0")``
+- ``load_dataset("org/dataset-name")`` without revision
+- ``load_dataset("org/dataset-name", revision="main")``
+- ``load_dataset("org/dataset-name", revision="v1.0")``
+- ``AutoTokenizer.from_pretrained("org/model-name")``
+- ``AutoTokenizer.from_pretrained("org/model-name", revision="main")``
+- ``AutoTokenizer.from_pretrained("org/model-name", revision="v3.3.0")``
+- ``hf_hub_download(repo_id="org/model_name", filename="file_name")``
+- ``hf_hub_download(repo_id="org/model_name", filename="file_name", revision="main")``
+- ``hf_hub_download(repo_id="org/model_name", filename="file_name", revision="v2.0.0")``
+- ``snapshot_download(repo_id="org/model_name")``
+- ``snapshot_download(repo_id="org/model_name", revision="main")``
+- ``snapshot_download(repo_id="org/model_name", revision="refs/pr/1")``
+
 
 :Example:
 
@@ -39,7 +51,6 @@ Common unsafe patterns:
 
      - https://cwe.mitre.org/data/definitions/494.html
      - https://huggingface.co/docs/huggingface_hub/en/guides/download#from-specific-version
-     - https://huggingface.co/docs/huggingface_hub/guides/download
 
 .. versionadded:: 1.9.0
 
@@ -99,7 +110,7 @@ def huggingface_unsafe_download(context):
     # Check for revision parameter (the key security control)
     revision_value = context.get_call_arg_value("revision")
     commit_id_value = context.get_call_arg_value("commit_id")
-    
+
     # Check if a revision or commit_id is specified
     revision_to_check = revision_value or commit_id_value
 

--- a/bandit/plugins/huggingface_unsafe_download.py
+++ b/bandit/plugins/huggingface_unsafe_download.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2024 PyCQA
+#
+# SPDX-License-Identifier: Apache-2.0
+r"""
+================================================
+B615: Test for unsafe Hugging Face Hub downloads
+================================================
+
+This plugin checks for unsafe downloads from Hugging Face Hub without proper
+integrity verification. Downloading models, datasets, or files without
+specifying a revision based on an immmutable revision (commit) can
+lead to supply chain attacks where malicious actors could
+replace model files and use an existing tag or branch name
+to serve malicious content.
+
+The secure approach is to:
+
+1. Pin to specific revisions/commits when downloading models, files or datasets
+
+Common unsafe patterns:
+- ``AutoModel.from_pretrained("model-name")`` without revision
+- ``load_dataset("dataset-name")`` without revision
+- ``hf_hub_download()`` without revision parameter
+- ``snapshot_download()`` without revision parameter
+
+:Example:
+
+.. code-block:: none
+
+        >> Issue: Unsafe Hugging Face Hub download without revision pinning
+        Severity: Medium   Confidence: High
+        CWE: CWE-494 (https://cwe.mitre.org/data/definitions/494.html)
+        Location: examples/huggingface_unsafe_download.py:8
+        7    # Unsafe: no revision specified
+        8    model = AutoModel.from_pretrained("org/model_name")
+        9
+
+.. seealso::
+
+     - https://cwe.mitre.org/data/definitions/494.html
+     - https://huggingface.co/docs/huggingface_hub/en/guides/download#from-specific-version
+     - https://huggingface.co/docs/huggingface_hub/guides/download
+
+.. versionadded:: 1.9.0
+
+"""
+import bandit
+from bandit.core import issue
+from bandit.core import test_properties as test
+
+
+@test.checks("Call")
+@test.test_id("B615")
+def huggingface_unsafe_download(context):
+    """
+    This plugin checks for unsafe artifact download from Hugging Face Hub 
+    without immutable/reproducible revision pinning.
+    """
+    # Check if any HuggingFace-related modules are imported
+    hf_modules = [
+        "transformers",
+        "datasets",
+        "huggingface_hub",
+    ]
+
+    # Check if any HF modules are imported
+    hf_imported = any(
+        context.is_module_imported_like(module) for module in hf_modules
+    )
+
+    if not hf_imported:
+        return
+
+    qualname = context.call_function_name_qual
+    if not isinstance(qualname, str):
+        return
+
+    unsafe_patterns = {
+        # transformers library patterns
+        "from_pretrained": ["transformers"],
+        # datasets library patterns
+        "load_dataset": ["datasets"],
+        # huggingface_hub patterns
+        "hf_hub_download": ["huggingface_hub"],
+        "snapshot_download": ["huggingface_hub"],
+        "repository_id": ["huggingface_hub"],
+    }
+
+    qualname_parts = qualname.split(".")
+    func_name = qualname_parts[-1]
+
+    if func_name not in unsafe_patterns:
+        return
+
+    required_modules = unsafe_patterns[func_name]
+    if not any(module in qualname_parts for module in required_modules):
+        return
+
+    # Check for revision parameter (the key security control)
+    revision_value = context.get_call_arg_value("revision")
+    commit_id_value = context.get_call_arg_value("commit_id")
+    
+    # Check if a revision or commit_id is specified
+    revision_to_check = revision_value or commit_id_value
+
+    if revision_to_check is not None:
+        # Check if it's a secure revision (looks like a commit hash)
+        # Commit hashes: 40 chars (full SHA) or 7+ chars (short SHA)
+        if isinstance(revision_to_check, str):
+            # Remove quotes if present
+            revision_str = str(revision_to_check).strip('"\'')
+
+            # Check if it looks like a commit hash (hexadecimal string)
+            # Must be at least 7 characters and all hexadecimal
+            hex_chars = '0123456789abcdefABCDEF'
+            is_hex = all(c in hex_chars for c in revision_str)
+            if len(revision_str) >= 7 and is_hex:
+                # This looks like a commit hash, which is secure
+                return
+
+    # Edge case: check if this is a local path (starts with ./ or /)
+    first_arg = context.get_call_arg_at_position(0)
+    if first_arg and isinstance(first_arg, str):
+        if first_arg.startswith(("./", "/", "../")):
+            # Local paths are generally safer
+            return
+
+    return bandit.Issue(
+        severity=bandit.MEDIUM,
+        confidence=bandit.HIGH,
+        text=(
+            f"Unsafe Hugging Face Hub download without revision pinning "
+            f"in {func_name}()"
+        ),
+        cwe=issue.Cwe.IMPROPER_INPUT_VALIDATION,
+        lineno=context.get_lineno_for_call_arg(func_name),
+    )

--- a/doc/source/plugins/b615_huggingface_unsafe_download.rst
+++ b/doc/source/plugins/b615_huggingface_unsafe_download.rst
@@ -1,0 +1,6 @@
+---------------------------------
+B615: huggingface_unsafe_download
+---------------------------------
+
+.. automodule:: bandit.plugins.huggingface_unsafe_download
+   :no-index:

--- a/examples/huggingface_unsafe_download.py
+++ b/examples/huggingface_unsafe_download.py
@@ -1,0 +1,149 @@
+from datasets import load_dataset
+from huggingface_hub import hf_hub_download, snapshot_download
+from transformers import AutoModel, AutoTokenizer
+
+# UNSAFE USAGE
+
+# AutoModel (Model Loading)
+
+# Example #1: No revision (defaults to floating 'main')
+unsafe_model_no_revision = AutoModel.from_pretrained("org/model_name")
+
+# Example #2: Floating revision: 'main'
+unsafe_model_main = AutoModel.from_pretrained(
+    "org/model_name",
+    revision="main"
+)
+
+# Example #3: Floating tag revision: 'v1.0.0'
+unsafe_model_tag = AutoModel.from_pretrained(
+    "org/model_name",
+    revision="v1.0.0"
+)
+
+
+# AutoTokenizer (Tokenizer Loading)
+
+# Example #4: No revision
+unsafe_tokenizer_no_revision = AutoTokenizer.from_pretrained("org/model_name")
+
+# Example #5: Floating revision: 'main'
+unsafe_tokenizer_main = AutoTokenizer.from_pretrained(
+    "org/model_name",
+    revision="main"
+)
+
+# Example #6: Floating tag revision: 'v1.0.0'
+unsafe_tokenizer_tag = AutoTokenizer.from_pretrained(
+    "org/model_name",
+    revision="v1.0.0"
+)
+
+
+# Example #7: load_dataset (Dataset Loading)
+
+# Example #8: No revision
+unsafe_dataset_no_revision = load_dataset("org_dataset")
+
+# Example #9: Floating revision: 'main'
+unsafe_dataset_main = load_dataset("org_dataset", revision="main")
+
+# Example #10: Floating tag revision: 'v1.0.0'
+unsafe_dataset_tag = load_dataset("org_dataset", revision="v1.0.0")
+
+
+# f_hub_download (File Download)
+
+# Example #11: No revision
+unsafe_file_no_revision = hf_hub_download(
+    repo_id="org/model_name",
+    filename="config.json"
+)
+
+# Example #12: Floating revision: 'main'
+unsafe_file_main = hf_hub_download(
+    repo_id="org/model_name",
+    filename="config.json",
+    revision="main"
+)
+
+# Example #13: Floating tag revision: 'v1.0.0'
+unsafe_file_tag = hf_hub_download(
+    repo_id="org/model_name",
+    filename="config.json",
+    revision="v1.0.0"
+)
+
+
+# snapshot_download (Repo Snapshot)
+
+# Example #14: No revision
+unsafe_snapshot_no_revision = snapshot_download(repo_id="org/model_name")
+
+# Example #15: Floating revision: 'main'
+unsafe_snapshot_main = snapshot_download(
+    repo_id="org/model_name",
+    revision="main"
+)
+
+# Example #16: Floating tag revision: 'v1.0.0'
+unsafe_snapshot_tag = snapshot_download(
+    repo_id="org/model_name",
+    revision="v1.0.0"
+)
+
+
+# -------------------------------
+# SAFE USAGE
+# -------------------------------
+
+# AutoModel
+
+# Example #17: Pinned commit hash
+safe_model_commit = AutoModel.from_pretrained(
+    "org/model_name",
+    revision="5d0f2e8a7f1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
+)
+
+# Example #18: Local path
+safe_model_local = AutoModel.from_pretrained("./local_model")
+safe_model_local_abs = AutoModel.from_pretrained("/path/to/model")
+
+# AutoTokenizer
+
+# Example #19: Pinned commit hash
+safe_tokenizer_commit = AutoTokenizer.from_pretrained(
+    "org/model_name",
+    revision="5d0f2e8a7f1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
+)
+
+# Example #20: Local path
+safe_tokenizer_local = AutoTokenizer.from_pretrained("./local_tokenizer")
+
+
+# load_dataset
+
+# Example #21: Pinned commit hash
+safe_dataset_commit = load_dataset(
+    "org_dataset",
+    revision="5d0f2e8a7f1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
+)
+
+
+# hf_hub_download
+
+# Example #22: Pinned commit hash
+safe_file_commit = hf_hub_download(
+    repo_id="org/model_name",
+    filename="config.json",
+    revision="5d0f2e8a7f1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
+)
+
+
+# snapshot_download
+
+# Example #23: Pinned commit hash
+safe_snapshot_commit = snapshot_download(
+    repo_id="org/model_name",
+    revision="5d0f2e8a7f1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
+)

--- a/setup.cfg
+++ b/setup.cfg
@@ -157,6 +157,9 @@ bandit.plugins =
     #bandit/plugins/pytorch_load.py
     pytorch_load = bandit.plugins.pytorch_load:pytorch_load
 
+    # bandit/plugins/huggingface_unsafe_download.py
+    huggingface_unsafe_download = bandit.plugins.huggingface_unsafe_download:huggingface_unsafe_download
+
     # bandit/plugins/trojansource.py
     trojansource = bandit.plugins.trojansource:trojansource
 

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -926,3 +926,10 @@ class FunctionalTests(testtools.TestCase):
             self.check_example(
                 "markupsafe_markup_xss_allowed_calls.py", expect
             )
+
+    def test_huggingface_unsafe_download(self):
+        expect = {
+            "SEVERITY": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 15, "HIGH": 0},
+            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 15},
+        }
+        self.check_example("huggingface_unsafe_download.py", expect)


### PR DESCRIPTION
In much the same way as unpinned container images benefit from digest pinning, fixing a model, dataset or file to a revision digest uniquely and immutably fixes use to a particular model snapshot (commit)

Example run:

```bash
bandit -r examples/huggingface_unsafe_download.py
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: None
[main]  INFO    running on Python 3.11.11
Run started:2025-06-26 10:53:35.832413

Test results:
>> Issue: [B615:huggingface_unsafe_download] Unsafe Hugging Face Hub download without revision pinning in from_pretrained()
   Severity: Medium   Confidence: High
   CWE: CWE-20 (https://cwe.mitre.org/data/definitions/20.html)
   More Info: https://bandit.readthedocs.io/en/1.8.6.dev2/plugins/b615_huggingface_unsafe_download.html
   Location: ./examples/huggingface_unsafe_download.py:10:27
9       # Example #1: No revision (defaults to floating 'main')
10      unsafe_model_no_revision = AutoModel.from_pretrained("org/model_name")
11

--------------------------------------------------
>> Issue: [B615:huggingface_unsafe_download] Unsafe Hugging Face Hub download without revision pinning in from_pretrained()
   Severity: Medium   Confidence: High
   CWE: CWE-20 (https://cwe.mitre.org/data/definitions/20.html)
   More Info: https://bandit.readthedocs.io/en/1.8.6.dev2/plugins/b615_huggingface_unsafe_download.html
   Location: ./examples/huggingface_unsafe_download.py:13:20
12      # Example #2: Floating revision: 'main'
13      unsafe_model_main = AutoModel.from_pretrained(
14          "org/model_name",
15          revision="main"
16      )
17

--------------------------------------------------
>> Issue: [B615:huggingface_unsafe_download] Unsafe Hugging Face Hub download without revision pinning in from_pretrained()
   Severity: Medium   Confidence: High
   CWE: CWE-20 (https://cwe.mitre.org/data/definitions/20.html)
   More Info: https://bandit.readthedocs.io/en/1.8.6.dev2/plugins/b615_huggingface_unsafe_download.html
   Location: ./examples/huggingface_unsafe_download.py:19:19
18      # Example #3: Floating tag revision: 'v1.0.0'
19      unsafe_model_tag = AutoModel.from_pretrained(
20          "org/model_name",
21          revision="v1.0.0"
22      )
23

--------------------------------------------------
>> Issue: [B615:huggingface_unsafe_download] Unsafe Hugging Face Hub download without revision pinning in from_pretrained()
   Severity: Medium   Confidence: High
   CWE: CWE-20 (https://cwe.mitre.org/data/definitions/20.html)
   More Info: https://bandit.readthedocs.io/en/1.8.6.dev2/plugins/b615_huggingface_unsafe_download.html
   Location: ./examples/huggingface_unsafe_download.py:28:31
27      # Example #4: No revision
28      unsafe_tokenizer_no_revision = AutoTokenizer.from_pretrained("org/model_name")
29

--------------------------------------------------
>> Issue: [B615:huggingface_unsafe_download] Unsafe Hugging Face Hub download without revision pinning in from_pretrained()
   Severity: Medium   Confidence: High
   CWE: CWE-20 (https://cwe.mitre.org/data/definitions/20.html)
   More Info: https://bandit.readthedocs.io/en/1.8.6.dev2/plugins/b615_huggingface_unsafe_download.html
   Location: ./examples/huggingface_unsafe_download.py:31:24
30      # Example #5: Floating revision: 'main'
31      unsafe_tokenizer_main = AutoTokenizer.from_pretrained(
32          "org/model_name",
33          revision="main"
34      )
35

--------------------------------------------------
>> Issue: [B615:huggingface_unsafe_download] Unsafe Hugging Face Hub download without revision pinning in from_pretrained()
   Severity: Medium   Confidence: High
   CWE: CWE-20 (https://cwe.mitre.org/data/definitions/20.html)
   More Info: https://bandit.readthedocs.io/en/1.8.6.dev2/plugins/b615_huggingface_unsafe_download.html
   Location: ./examples/huggingface_unsafe_download.py:37:23
36      # Example #6: Floating tag revision: 'v1.0.0'
37      unsafe_tokenizer_tag = AutoTokenizer.from_pretrained(
38          "org/model_name",
39          revision="v1.0.0"
40      )
41

--------------------------------------------------
>> Issue: [B615:huggingface_unsafe_download] Unsafe Hugging Face Hub download without revision pinning in load_dataset()
   Severity: Medium   Confidence: High
   CWE: CWE-20 (https://cwe.mitre.org/data/definitions/20.html)
   More Info: https://bandit.readthedocs.io/en/1.8.6.dev2/plugins/b615_huggingface_unsafe_download.html
   Location: ./examples/huggingface_unsafe_download.py:46:29
45      # Example #8: No revision
46      unsafe_dataset_no_revision = load_dataset("org_dataset")
47

--------------------------------------------------
>> Issue: [B615:huggingface_unsafe_download] Unsafe Hugging Face Hub download without revision pinning in load_dataset()
   Severity: Medium   Confidence: High
   CWE: CWE-20 (https://cwe.mitre.org/data/definitions/20.html)
   More Info: https://bandit.readthedocs.io/en/1.8.6.dev2/plugins/b615_huggingface_unsafe_download.html
   Location: ./examples/huggingface_unsafe_download.py:49:22
48      # Example #9: Floating revision: 'main'
49      unsafe_dataset_main = load_dataset("org_dataset", revision="main")
50

--------------------------------------------------
>> Issue: [B615:huggingface_unsafe_download] Unsafe Hugging Face Hub download without revision pinning in load_dataset()
   Severity: Medium   Confidence: High
   CWE: CWE-20 (https://cwe.mitre.org/data/definitions/20.html)
   More Info: https://bandit.readthedocs.io/en/1.8.6.dev2/plugins/b615_huggingface_unsafe_download.html
   Location: ./examples/huggingface_unsafe_download.py:52:21
51      # Example #10: Floating tag revision: 'v1.0.0'
52      unsafe_dataset_tag = load_dataset("org_dataset", revision="v1.0.0")
53

--------------------------------------------------
>> Issue: [B615:huggingface_unsafe_download] Unsafe Hugging Face Hub download without revision pinning in hf_hub_download()
   Severity: Medium   Confidence: High
   CWE: CWE-20 (https://cwe.mitre.org/data/definitions/20.html)
   More Info: https://bandit.readthedocs.io/en/1.8.6.dev2/plugins/b615_huggingface_unsafe_download.html
   Location: ./examples/huggingface_unsafe_download.py:58:26
57      # Example #11: No revision
58      unsafe_file_no_revision = hf_hub_download(
59          repo_id="org/model_name",
60          filename="config.json"
61      )
62

--------------------------------------------------
>> Issue: [B615:huggingface_unsafe_download] Unsafe Hugging Face Hub download without revision pinning in hf_hub_download()
   Severity: Medium   Confidence: High
   CWE: CWE-20 (https://cwe.mitre.org/data/definitions/20.html)
   More Info: https://bandit.readthedocs.io/en/1.8.6.dev2/plugins/b615_huggingface_unsafe_download.html
   Location: ./examples/huggingface_unsafe_download.py:64:19
63      # Example #12: Floating revision: 'main'
64      unsafe_file_main = hf_hub_download(
65          repo_id="org/model_name",
66          filename="config.json",
67          revision="main"
68      )
69

--------------------------------------------------
>> Issue: [B615:huggingface_unsafe_download] Unsafe Hugging Face Hub download without revision pinning in hf_hub_download()
   Severity: Medium   Confidence: High
   CWE: CWE-20 (https://cwe.mitre.org/data/definitions/20.html)
   More Info: https://bandit.readthedocs.io/en/1.8.6.dev2/plugins/b615_huggingface_unsafe_download.html
   Location: ./examples/huggingface_unsafe_download.py:71:18
70      # Example #13: Floating tag revision: 'v1.0.0'
71      unsafe_file_tag = hf_hub_download(
72          repo_id="org/model_name",
73          filename="config.json",
74          revision="v1.0.0"
75      )
76

--------------------------------------------------
>> Issue: [B615:huggingface_unsafe_download] Unsafe Hugging Face Hub download without revision pinning in snapshot_download()
   Severity: Medium   Confidence: High
   CWE: CWE-20 (https://cwe.mitre.org/data/definitions/20.html)
   More Info: https://bandit.readthedocs.io/en/1.8.6.dev2/plugins/b615_huggingface_unsafe_download.html
   Location: ./examples/huggingface_unsafe_download.py:81:30
80      # Example #14: No revision
81      unsafe_snapshot_no_revision = snapshot_download(repo_id="org/model_name")
82

--------------------------------------------------
>> Issue: [B615:huggingface_unsafe_download] Unsafe Hugging Face Hub download without revision pinning in snapshot_download()
   Severity: Medium   Confidence: High
   CWE: CWE-20 (https://cwe.mitre.org/data/definitions/20.html)
   More Info: https://bandit.readthedocs.io/en/1.8.6.dev2/plugins/b615_huggingface_unsafe_download.html
   Location: ./examples/huggingface_unsafe_download.py:84:23
83      # Example #15: Floating revision: 'main'
84      unsafe_snapshot_main = snapshot_download(
85          repo_id="org/model_name",
86          revision="main"
87      )
88

--------------------------------------------------
>> Issue: [B615:huggingface_unsafe_download] Unsafe Hugging Face Hub download without revision pinning in snapshot_download()
   Severity: Medium   Confidence: High
   CWE: CWE-20 (https://cwe.mitre.org/data/definitions/20.html)
   More Info: https://bandit.readthedocs.io/en/1.8.6.dev2/plugins/b615_huggingface_unsafe_download.html
   Location: ./examples/huggingface_unsafe_download.py:90:22
89      # Example #16: Floating tag revision: 'v1.0.0'
90      unsafe_snapshot_tag = snapshot_download(
91          repo_id="org/model_name",
92          revision="v1.0.0"
93      )
94

--------------------------------------------------

Code scanned:
        Total lines of code: 71
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0
                Low: 0
                Medium: 15
                High: 0
        Total issues (by confidence):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 15
Files skipped (0):