### PR TITLE
added hint to FreeBSD package in doc/source/integrations.rst

### DIFF
--- a/doc/source/integrations.rst
+++ b/doc/source/integrations.rst
@@ -53,6 +53,8 @@ Packages
      - `bandit <https://packages.ubuntu.com/search?keywords=bandit&searchon=names&section=all>`_
    * - Homebrew
      - `bandit <https://formulae.brew.sh/formula/bandit>`_
+   * - FreeBSD
+     - `py-bandit <https://www.freshports.org/devel/py-bandit/>`_
 
 
 🙌 Contributions Welcome


### PR DESCRIPTION
I did not integrate Bandit to FreeBSD, but it is already available there. I'm not a developer/maintainer of the FreeBSD package: [py-bandit](https://www.freshports.org/devel/py-bandit/)