### PR TITLE
fixed bug no version detected in pre-commit installation

### DIFF
--- a/bandit/__init__.py
+++ b/bandit/__init__.py
@@ -18,7 +18,6 @@ from bandit.core.test_properties import *  # noqa
 
 __author__ = metadata.metadata("bandit")["Author"]
 __version__ = metadata.version("bandit")
-# __version__ = metadata.version(__package__)
 # running bandit inside pre-commit we do not get a version here, workaround:
 if __version__ == "0.0.0":
     __version__ = "latest"


### PR DESCRIPTION
cf. https://github.com/PyCQA/bandit/issues/1280

Unfortunately, `metadata.version("bandit")` does not return a meaningful version (returning the string "0.0.0") when `bandit` is installed and used via `pre-commit`.

This PR provides a workaround to ensure `bandit` functions correctly within the `pre-commit` environment.  

`pre-commit` does not seem to provide the right environment for version detection. The use of 'latest' ensures compatibility, even if this is more of a workaround than a perfect solution.