### PR TITLE
Python 3.14 compatibility fixes

### DIFF
--- a/bandit/core/blacklisting.py
+++ b/bandit/core/blacklisting.py
@@ -36,7 +36,7 @@ def blacklist(context, config):
         if isinstance(func, ast.Name) and func.id == "__import__":
             if len(context.node.args):
                 if isinstance(context.node.args[0], ast.Str):
-                    name = context.node.args[0].s
+                    name = context.node.args[0].value
                 else:
                     # TODO(??): import through a variable, need symbol tab
                     name = "UNKNOWN"

--- a/bandit/core/context.py
+++ b/bandit/core/context.py
@@ -178,11 +178,8 @@ class Context:
         :param literal: The AST literal to convert
         :return: The value of the AST literal
         """
-        if isinstance(literal, ast.Num):
-            literal_value = literal.n
-
-        elif isinstance(literal, ast.Str):
-            literal_value = literal.s
+        if isinstance(literal, ast.Constant):
+            literal_value = literal.value
 
         elif isinstance(literal, ast.List):
             return_list = list()
@@ -205,18 +202,8 @@ class Context:
         elif isinstance(literal, ast.Dict):
             literal_value = dict(zip(literal.keys, literal.values))
 
-        elif isinstance(literal, ast.Ellipsis):
-            # what do we want to do with this?
-            literal_value = None
-
         elif isinstance(literal, ast.Name):
             literal_value = literal.id
-
-        elif isinstance(literal, ast.NameConstant):
-            literal_value = str(literal.value)
-
-        elif isinstance(literal, ast.Bytes):
-            literal_value = literal.s
 
         else:
             literal_value = None

--- a/bandit/core/node_visitor.py
+++ b/bandit/core/node_visitor.py
@@ -168,7 +168,7 @@ class BanditNodeVisitor:
         :param node: The node that is being inspected
         :return: -
         """
-        self.context["str"] = node.s
+        self.context["str"] = node.value
         if not isinstance(node._bandit_parent, ast.Expr):  # docstring
             self.context["linerange"] = b_utils.linerange(node._bandit_parent)
             self.update_scores(self.tester.run_tests(self.context, "Str"))
@@ -181,7 +181,7 @@ class BanditNodeVisitor:
         :param node: The node that is being inspected
         :return: -
         """
-        self.context["bytes"] = node.s
+        self.context["bytes"] = node.value
         if not isinstance(node._bandit_parent, ast.Expr):  # docstring
             self.context["linerange"] = b_utils.linerange(node._bandit_parent)
             self.update_scores(self.tester.run_tests(self.context, "Bytes"))

--- a/bandit/core/utils.py
+++ b/bandit/core/utils.py
@@ -300,7 +300,7 @@ def concat_string(node, stop=None):
         node = node._bandit_parent
     if isinstance(node, ast.BinOp):
         _get(node, bits, stop)
-    return (node, " ".join([x.s for x in bits if isinstance(x, ast.Str)]))
+    return (node, " ".join([x.value for x in bits if isinstance(x, ast.Str)]))
 
 
 def get_called_name(node):

--- a/bandit/plugins/general_hardcoded_password.py
+++ b/bandit/plugins/general_hardcoded_password.py
@@ -101,7 +101,7 @@ def hardcoded_password_string(context):
             return _report(assign.value.s)
 
     elif isinstance(node._bandit_parent, ast.Index) and RE_CANDIDATES.search(
-        node.s
+        node.value
     ):
         # looks for "dict[candidate]='some_string'"
         # assign -> subscript -> index -> string

--- a/bandit/plugins/injection_sql.py
+++ b/bandit/plugins/injection_sql.py
@@ -96,7 +96,7 @@ def _evaluate_ast(node):
     elif isinstance(
         node._bandit_parent, ast.Attribute
     ) and node._bandit_parent.attr in ("format", "replace"):
-        statement = node.s
+        statement = node.value
         # Hierarchy for "".format() is Wrapper -> Call -> Attribute -> Str
         wrapper = node._bandit_parent._bandit_parent._bandit_parent
         if node._bandit_parent.attr == "replace":

--- a/bandit/plugins/tarfile_unsafe_members.py
+++ b/bandit/plugins/tarfile_unsafe_members.py
@@ -98,7 +98,7 @@ def is_filter_data(context):
     for keyword in context.node.keywords:
         if keyword.arg == "filter":
             arg = keyword.value
-            return isinstance(arg, ast.Str) and arg.s == "data"
+            return isinstance(arg, ast.Str) and arg.value == "data"
 
 
 @test.test_id("B202")

--- a/tests/unit/core/test_context.py
+++ b/tests/unit/core/test_context.py
@@ -137,7 +137,7 @@ class ContextTests(testtools.TestCase):
         self.assertEqual(expected, new_context._get_literal_value(value))
 
         value = ast.Str("spam")
-        expected = value.s
+        expected = value.value
         self.assertEqual(expected, new_context._get_literal_value(value))
 
         value = ast.List([ast.Str("spam"), ast.Num(42)], ast.Load())
@@ -164,7 +164,7 @@ class ContextTests(testtools.TestCase):
         self.assertEqual(expected, new_context._get_literal_value(value))
 
         value = ast.Bytes(b"spam")
-        expected = value.s
+        expected = value.value
         self.assertEqual(expected, new_context._get_literal_value(value))
 
         self.assertIsNone(new_context._get_literal_value(None))


### PR DESCRIPTION
Use node.value, not node.s which has was previously deprecated but has now been removed in Python 3.14.

Remove obsolete AST types that are supplanted by `ast.Constant`.