### PR TITLE
Replace deprecated datetime.datetime.utcnow()

### DIFF
--- a/bandit/formatters/json.py
+++ b/bandit/formatters/json.py
@@ -139,7 +139,9 @@ def report(manager, fileobj, sev_level, conf_level, lines=-1):
     # timezone agnostic format
     TS_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
-    time_string = datetime.datetime.utcnow().strftime(TS_FORMAT)
+    time_string = datetime.datetime.now(datetime.timezone.utc).strftime(
+        TS_FORMAT
+    )
     machine_output["generated_at"] = time_string
 
     result = json.dumps(

--- a/bandit/formatters/sarif.py
+++ b/bandit/formatters/sarif.py
@@ -125,11 +125,11 @@ This formatter outputs the issues in SARIF formatted JSON.
 .. versionadded:: 1.7.8
 
 """  # noqa: E501
+import datetime
 import logging
 import pathlib
 import sys
 import urllib.parse as urlparse
-from datetime import datetime
 
 import sarif_om as om
 from jschema_to_python.to_json import to_json
@@ -168,7 +168,9 @@ def report(manager, fileobj, sev_level, conf_level, lines=-1):
                 ),
                 invocations=[
                     om.Invocation(
-                        end_time_utc=datetime.utcnow().strftime(TS_FORMAT),
+                        end_time_utc=datetime.datetime.now(
+                            datetime.timezone.utc
+                        ).strftime(TS_FORMAT),
                         execution_successful=True,
                     )
                 ],

--- a/bandit/formatters/screen.py
+++ b/bandit/formatters/screen.py
@@ -205,7 +205,11 @@ def report(manager, fileobj, sev_level, conf_level, lines=-1):
 
     bits = []
     if not manager.quiet or manager.results_count(sev_level, conf_level):
-        bits.append(header("Run started:%s", datetime.datetime.utcnow()))
+        bits.append(
+            header(
+                "Run started:%s", datetime.datetime.now(datetime.timezone.utc)
+            )
+        )
 
         if manager.verbose:
             bits.append(get_verbose_details(manager))

--- a/bandit/formatters/text.py
+++ b/bandit/formatters/text.py
@@ -161,7 +161,9 @@ def report(manager, fileobj, sev_level, conf_level, lines=-1):
     bits = []
 
     if not manager.quiet or manager.results_count(sev_level, conf_level):
-        bits.append(f"Run started:{datetime.datetime.utcnow()}")
+        bits.append(
+            f"Run started:{datetime.datetime.now(datetime.timezone.utc)}"
+        )
 
         if manager.verbose:
             bits.append(get_verbose_details(manager))

--- a/bandit/formatters/yaml.py
+++ b/bandit/formatters/yaml.py
@@ -115,7 +115,9 @@ def report(manager, fileobj, sev_level, conf_level, lines=-1):
     # timezone agnostic format
     TS_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
-    time_string = datetime.datetime.utcnow().strftime(TS_FORMAT)
+    time_string = datetime.datetime.now(datetime.timezone.utc).strftime(
+        TS_FORMAT
+    )
     machine_output["generated_at"] = time_string
 
     yaml.safe_dump(machine_output, fileobj, default_flow_style=False)


### PR DESCRIPTION
Deprecated since Python 3.12: https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow 

Using `datetime.datetime.now(datetime.timezone.utc)` instead – which is compatible with Python 3.9+

Closes #1294 