### PR TITLE
Improved GUI, TUI and CLI interface

### DIFF
--- a/bandit/cli/get_env.py
+++ b/bandit/cli/get_env.py
@@ -1,0 +1,120 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Literal, Annotated, TextIO
+from pathlib import Path
+import sys
+import os
+from mininterface import Validation
+from mininterface.validators import not_empty
+import tyro
+from tyro.conf import Positional, UseCounterAction, arg
+
+
+from ..core import constants
+from ..core.extension_loader import Manager
+
+class Level(Enum):
+    ALL = 1
+    LOW = 2
+    MEDIUM = 3
+    HIGH = 4
+
+    @classmethod
+    def get_annotation(cls):
+        return Optional[Literal[tuple(s.lower() for s in Level._member_names_)]]
+
+    @classmethod
+    def get(cls, key:str):
+        return cls[key.upper()]
+
+
+
+def get_env(extension_mgr: Manager):
+
+    output_format_default = (
+        "screen"
+        if (
+            sys.stdout.isatty()
+            and os.getenv("NO_COLOR") is None
+            and os.getenv("TERM") != "dumb"
+        )
+        else "txt"
+    )
+
+    MutexSev = tyro.conf.create_mutex_group(required=False)
+    MutexConfid = tyro.conf.create_mutex_group(required=False)
+    MutexVerbosity = tyro.conf.create_mutex_group(required=False)
+
+    @dataclass
+    class Env:
+        targets: Annotated[Positional[list[Path]], Validation(not_empty)]
+        """Source file(s) or directory(s) to be tested"""
+
+        recursive: Annotated[bool, arg(aliases=["-r"])] = False
+        """Find and process files in subdirectories"""
+
+        aggregate: Annotated[Literal["file", "vuln"], arg(aliases=["-a"])] = "file"
+        """Aggregate output by vulnerability (default) or by filename"""
+
+        context_lines: Annotated[int, arg(aliases=["-n"])] = 3
+        """Maximum number of code lines to output for each issue"""
+
+        configfile: Annotated[Optional[Path], arg(aliases=["-c"])] = None
+        """Optional config file to use for selecting plugins and overriding defaults"""
+
+        profile: Annotated[Optional[str], arg(aliases=["-p"])] = None
+        """Profile to use (defaults to executing all tests)"""
+
+        tests: Annotated[Optional[str], arg(aliases=["-t"])] = None
+        """Comma-separated list of test IDs to run"""
+
+        skips: Annotated[Optional[str], arg(aliases=["-s"])] = None
+        """Comma-separated list of test IDs to skip"""
+
+        level: Annotated[UseCounterAction[int], arg(aliases=["-l"]), MutexSev] = 1
+        """Report only issues of a given severity level or higher (-l for LOW, -ll for MEDIUM, -lll for HIGH)"""
+
+        severity_level: Annotated[Level.get_annotation(), MutexSev] = None
+        """Report only issues of a given severity level or higher ('all', 'low', 'medium', 'high')"""
+
+        confidence: Annotated[UseCounterAction[int], arg(aliases=["-i"]), MutexConfid] = 1
+        """Report only issues of a given confidence level or higher (-i for LOW, -ii for MEDIUM, -iii for HIGH)"""
+
+        confidence_level: Annotated[Level.get_annotation(),MutexConfid] = None
+        """Report only issues of a given confidence level or higher ('all', 'low', 'medium', 'high')"""
+
+        format: Annotated[Literal[tuple(sorted(extension_mgr.formatter_names))], arg(aliases=["-f"])] = output_format_default
+        """Specify output format"""
+
+        msg_template: Optional[str] = None
+        """Specify output message template (only usable with --format custom)"""
+
+        output: Annotated[Optional[Path], arg(aliases=["-o"], help_behavior_hint="")] = None
+        """Write report to filename (defaults to stdout)"""
+
+        verbose: Annotated[bool, MutexVerbosity, arg(aliases=["-v"])] = False
+        """Output extra information like excluded and included files"""
+
+        debug: Annotated[bool, MutexVerbosity, arg(aliases=["-d"])] = False
+        """Turn on debug mode"""
+
+        quiet: Annotated[bool, MutexVerbosity, arg(aliases=["-q", "--silent"])] = False
+        """Only show output in the case of an error"""
+
+        ignore_nosec: Annotated[bool, MutexVerbosity, arg(aliases=["--ignore-nosec"])] = False
+        """Do not skip lines with # nosec comments"""
+
+        excluded_paths: Annotated[tuple, arg(aliases=["-x", "--exclude"])] = constants.EXCLUDE
+        """List of paths (glob patterns supported) to exclude from scan (note that these are in addition to the excluded paths provided in the config file)"""
+        # TODO mají se přidat, ne nahradit
+        # TODO zus to pustit
+
+        baseline: Annotated[Optional[str], arg(aliases=["-b"])] = None
+        """Path of a baseline report to compare against (only JSON-formatted files)"""
+
+        ini_path: Annotated[Optional[Path], arg(aliases=["--ini"])] = None
+        """Path to a .bandit file that supplies command line arguments"""
+
+        exit_zero: bool = False
+        """Exit with 0, even with results found"""
+    return Env

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ PyYAML>=5.3.1 # MIT
 stevedore>=1.20.0 # Apache-2.0
 colorama>=0.3.9;platform_system=="Windows" # BSD License (3 clause)
 rich # MIT
+mininterface[basic]<2


### PR DESCRIPTION
My proposal is to implement miniterface, a versatile CLI and dialog toolkit. This gives us various advantages.

# Automatic GUI and colourful helps

If left empty, there is an automatic wizzard. Note the file/dir-picker buttons.

```bash
$ bandit
```

<img width="1091" height="1109" alt="image" src="https://github.com/user-attachments/assets/b47ee898-825b-42fe-b823-11463fc11a35" />

See nicer output and colour when invoking help.

```bash
$ bandit --help
╭─ positional arguments ─────────────────────────────────────────────────────╮
│ [PATH [PATH ...]]       Source file(s) or directory(s) to be tested        │
│                         (required)                                         │
╰────────────────────────────────────────────────────────────────────────────╯
╭─ options ──────────────────────────────────────────────────────────────────╮
│ -h, --help              show this help message and exit                    │
│ --version               show program's version number (%(prog)s 1.8.6      │
│                           python version = 3.12.3 (main, Aug 14 2025,      │
│                         17:47:21) [GCC 13.3.0]) and exit                   │
│ -r, --recursive         Find and process files in subdirectories (default: │
│                         False)                                             │
...
```

# Automatic TUI

On machines without display (ex. through SSH), there is an automatic fallback for a mouse-clickable text interface.

```bash
$ bandit
```

<img width="866" height="813" alt="image" src="https://github.com/user-attachments/assets/5ef24919-6862-46e2-bf44-f4b8c0018187" />

# Transparent parser

Instead of the `argparse`, I've refactored the configuration to dataclasses. This improves readibility, allows the type to be defined only there on one place etc.

# IDE benefits

Automatic type control, IDE suggestions and IDE is now able to show hints. See the value (`Literal`) and the programmer's comment (`Accept pre/post hooks`) which would be impossible with the old `argparse`.

<img width="634" height="150" alt="image" src="https://github.com/user-attachments/assets/41533c2d-7158-4f16-8dc7-ffe0a40906be" />

# Conclusion

Are you interested in this PR? What do you think? Are there any changes I should catch up?

If you agree, I'll take a look at the tests to ensure the functionality stays the same.