### PR TITLE
More Python version related fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -44,7 +44,12 @@ body:
       label: Bandit version
       description: Run "bandit --version" if unsure of version number
       options:
-        - 1.8.3 (Default)
+        - 1.9.1 (Default)
+        - 1.9.0
+        - 1.8.6
+        - 1.8.5
+        - 1.8.4
+        - 1.8.3
         - 1.8.2
         - 1.8.1
         - 1.8.0
@@ -53,12 +58,6 @@ body:
         - 1.7.8
         - 1.7.7
         - 1.7.6
-        - 1.7.5
-        - 1.7.4
-        - 1.7.3
-        - 1.7.2
-        - 1.7.1
-        - 1.7.0
     validations:
       required: true
 
@@ -68,7 +67,8 @@ body:
       label: Python version
       description: Run "bandit --version" if unsure of version number
       options:
-        - "3.13 (Default)"
+        - "3.14 (Default)"
+        - "3.13"
         - "3.12"
         - "3.11"
         - "3.10"

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v6
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: Install dependencies
       run: pip install tox wheel

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v6
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: Install dependencies
       run: pip install tox wheel


### PR DESCRIPTION
* Put python versions in quotes for the publish build step. This is required, since the publish of 1.9.0 failed as 3.10 mapped to 3.1. https://github.com/PyCQA/bandit/actions/runs/19397103776
* Added version 1.9.1 (future after this fix) and 1.9.0 as supported versions in the bug template
* Also dropped Bandit versions over 2 years old from bug template

Fixes #1329