### PR TITLE
Quote Python version strings

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v6
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: Install dependencies
       run: pip install tox wheel

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v6
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: Install dependencies
       run: pip install tox wheel


### PR DESCRIPTION
Otherwise they will be interpreted as floating-point numbers by GitHub Actions.  This is a problem in the case of Python 3.10, since GitHub Actions interprets `3.10` (without quotes) as `3.1`.  This is causing the GitHub Actions workflows that publish to PyPI and Test PyPI to [fail](https://github.com/PyCQA/bandit/actions/runs/19397103776), as described in #1329.

After this change it should be possible to create a new release and thereby resolve #1329.