### PR TITLE
Argparse Python 3.14 enhancements

### DIFF
--- a/bandit/cli/baseline.py
+++ b/bandit/cli/baseline.py
@@ -168,6 +168,9 @@ def initialize():
         epilog="Additional Bandit arguments such as severity filtering (-ll) "
         "can be added and will be passed to Bandit.",
     )
+    if sys.version_info >= (3, 14):
+        parser.suggest_on_error = True
+        parser.color = False
 
     parser.add_argument(
         "targets",

--- a/bandit/cli/config_generator.py
+++ b/bandit/cli/config_generator.py
@@ -76,6 +76,9 @@ def parse_args():
         description=help_description,
         formatter_class=argparse.RawTextHelpFormatter,
     )
+    if sys.version_info >= (3, 14):
+        parser.suggest_on_error = True
+        parser.color = False
 
     parser.add_argument(
         "--show-defaults",

--- a/bandit/cli/main.py
+++ b/bandit/cli/main.py
@@ -155,6 +155,10 @@ def main():
         description="Bandit - a Python source code security analyzer",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    if sys.version_info >= (3, 14):
+        parser.suggest_on_error = True
+        parser.color = False
+
     parser.add_argument(
         "targets",
         metavar="targets",


### PR DESCRIPTION
The argparse lib in Py314 now can do suggestion of an argument when a typo is given. It only works on choices, but regardless it can be handy to users of Bandit. Besides Python 3.15 plans to enable this by default.

The other change is the color being disabled. Color in CLIs defaults to True in Python 3.14. And frankly it doesn't look good. Way too many colors being used.

https://docs.python.org/3/library/argparse.html#suggest-on-error