### PR TITLE
Check whether Constant value is str

### DIFF
--- a/bandit/core/utils.py
+++ b/bandit/core/utils.py
@@ -302,7 +302,13 @@ def concat_string(node, stop=None):
         _get(node, bits, stop)
     return (
         node,
-        " ".join([x.value for x in bits if isinstance(x, ast.Constant)]),
+        " ".join(
+            [
+                x.value
+                for x in bits
+                if isinstance(x, ast.Constant) and isinstance(x.value, str)
+            ]
+        ),
     )
 
 


### PR DESCRIPTION
This change fixes a case of a missed check on the value of a ast.Constant to be a str or not. PR #1323 fixed many of these as part of the Python 3.14 compatibility since ast.Str was removed. So when checking ast.Constant, the value can many types of literals, not just str.

Note: I tested before and after this fix using the repo given in the issue.

Fixes #1332