### PR TITLE
Fix B608 to detect `VALUES(` without space

### DIFF
--- a/bandit/plugins/injection_sql.py
+++ b/bandit/plugins/injection_sql.py
@@ -74,7 +74,7 @@ from bandit.core import utils
 SIMPLE_SQL_RE = re.compile(
     r"(select\s.*from\s|"
     r"delete\s+from\s|"
-    r"insert\s+into\s.*values\s|"
+    r"insert\s+into\s.*values[\s(]|"
     r"update\s.*set\s)",
     re.IGNORECASE | re.DOTALL,
 )

--- a/examples/sql_statements.py
+++ b/examples/sql_statements.py
@@ -3,6 +3,7 @@ import sqlalchemy
 # bad
 query = "SELECT * FROM foo WHERE id = '%s'" % identifier
 query = "INSERT INTO foo VALUES ('a', 'b', '%s')" % value
+query = "INSERT INTO foo VALUES('a', 'b', '%s')" % value
 query = "DELETE FROM foo WHERE id = '%s'" % identifier
 query = "UPDATE foo SET value = 'b' WHERE id = '%s'" % identifier
 query = """WITH cte AS (SELECT x FROM foo)
@@ -15,6 +16,7 @@ query = "SELECT * FROM foo WHERE id = '[VALUE]'".replace("[VALUE]", identifier)
 # bad
 cur.execute("SELECT * FROM foo WHERE id = '%s'" % identifier)
 cur.execute("INSERT INTO foo VALUES ('a', 'b', '%s')" % value)
+cur.execute("INSERT INTO foo VALUES('a', 'b', '%s')" % value)
 cur.execute("DELETE FROM foo WHERE id = '%s'" % identifier)
 cur.execute("UPDATE foo SET value = 'b' WHERE id = '%s'" % identifier)
 # bad alternate forms
@@ -26,11 +28,13 @@ cur.execute("SELECT * FROM foo WHERE id = '[VALUE]'".replace("[VALUE]", identifi
 cur.execute(f"SELECT {column_name} FROM foo WHERE id = 1")
 cur.execute(f"SELECT {a + b} FROM foo WHERE id = 1")
 cur.execute(f"INSERT INTO {table_name} VALUES (1)")
+cur.execute(f"INSERT INTO {table_name} VALUES(1)")
 cur.execute(f"UPDATE {table_name} SET id = 1")
 
 # good
 cur.execute("SELECT * FROM foo WHERE id = '%s'", identifier)
 cur.execute("INSERT INTO foo VALUES ('a', 'b', '%s')", value)
+cur.execute("INSERT INTO foo VALUES('a', 'b', '%s')", value)
 cur.execute("DELETE FROM foo WHERE id = '%s'", identifier)
 cur.execute("UPDATE foo SET value = 'b' WHERE id = '%s'", identifier)
 

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -408,13 +408,13 @@ class FunctionalTests(testtools.TestCase):
             "SEVERITY": {
                 "UNDEFINED": 0,
                 "LOW": 0,
-                "MEDIUM": 20,
+                "MEDIUM": 23,
                 "HIGH": 0,
             },
             "CONFIDENCE": {
                 "UNDEFINED": 0,
-                "LOW": 10,
-                "MEDIUM": 10,
+                "LOW": 11,
+                "MEDIUM": 12,
                 "HIGH": 0,
             },
         }


### PR DESCRIPTION
The current regex pattern for INSERT statements requires a whitespace character after `VALUES`,
but `VALUES(` is valid SQL syntax and commonly used.
This causes potential SQL injection cases to go undetected.

Changed the regex from `values\s` to `values[\s(]` to match both `VALUES (` and `VALUES(` patterns.

Resolves: #1336