### PR TITLE
Update tox tests for Python 3.10

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ You can test any changes with tox:
 pip install tox
 tox run -e pep8
 tox run -e format
-tox run -e py39
+tox run -e py310
 tox run -e docs
 tox run -e cover
 ```


### PR DESCRIPTION
Bandit requires a Python version 3.10 or greater. CONTRIBUTING.md includes a required test running Python 3.9. This updates the test in the documentation for Python 3.10.