### PR TITLE
Lower version guard in check_ast_node to Python 3.12

### DIFF
--- a/bandit/core/utils.py
+++ b/bandit/core/utils.py
@@ -370,9 +370,9 @@ def parse_ini_file(f_loc):
 def check_ast_node(name):
     "Check if the given name is that of a valid AST node."
     try:
-        # These ast Node types don't exist in Python 3.14, but plugins may
-        # still check on them.
-        if sys.version_info >= (3, 14) and name in (
+        # These ast Node types were deprecated in Python 3.12 and removed
+        # in Python 3.14, but plugins may still check on them.
+        if sys.version_info >= (3, 12) and name in (
             "Num",
             "Str",
             "Ellipsis",


### PR DESCRIPTION
## Summary

The version guard in `check_ast_node()` for deprecated AST node types (`Num`, `Str`, `Bytes`, `Ellipsis`, `NameConstant`) currently activates only on Python >= 3.14, where these types are fully removed. However, accessing these types via `getattr(ast, name)` emits `DeprecationWarning` on Python 3.12 and 3.13.

This one-line change lowers the guard from `(3, 14)` to `(3, 12)` to avoid the deprecation warning on currently-supported Python versions.

## Background

PR #1323 introduced the version guard targeting Python 3.14 where these AST types were removed entirely. The guard correctly short-circuits to return the name without calling `getattr(ast, name)`. However, the runtime `DeprecationWarning` for these types was added in Python 3.12 (see [Python 3.12 docs: Pending removal in 3.14](https://docs.python.org/3.12/deprecations/pending-removal-in-3.14.html), contributed by Serhiy Storchaka in [CPython gh-90953](https://github.com/python/cpython/issues/90953)), and the `getattr` call triggers this warning on 3.12 and 3.13.

Four plugins register checks against the `"Str"` node type, causing the warning to fire during plugin loading:

- `general_bind_all_interfaces.py`
- `general_hardcoded_password.py`
- `general_hardcoded_tmp.py`
- `injection_sql.py`

## Change

```diff
-        if sys.version_info >= (3, 14) and name in (
+        if sys.version_info >= (3, 12) and name in (
```

The early return value is unchanged: the node name is known-valid and is returned directly. The only difference is that we skip the `getattr` call that triggers the warning.

## Testing

Existing tests pass unchanged. The early-return path produces the same result as the `getattr` path for these known node names.