### PR TITLE
Fix B615 false positive when revision is set via variable

### DIFF
--- a/bandit/plugins/huggingface_unsafe_download.py
+++ b/bandit/plugins/huggingface_unsafe_download.py
@@ -59,6 +59,7 @@ Common unsafe patterns:
 .. versionadded:: 1.8.6
 
 """
+import ast
 import string
 
 import bandit
@@ -113,7 +114,19 @@ def huggingface_unsafe_download(context):
     if not any(module in qualname_parts for module in required_modules):
         return
 
-    # Check for revision parameter (the key security control)
+    # Check for revision parameter (the key security control).
+    # First, check the raw AST to see if a revision/commit_id keyword was
+    # passed as a non-literal expression (variable, attribute, subscript,
+    # function call, etc.).  In those cases we cannot statically determine
+    # the value, so we give the user the benefit of the doubt.
+    call_node = context._context.get("call")
+    if call_node is not None:
+        for kw in getattr(call_node, "keywords", []):
+            if kw.arg in ("revision", "commit_id") and not isinstance(
+                kw.value, ast.Constant
+            ):
+                return
+
     revision_value = context.get_call_arg_value("revision")
     commit_id_value = context.get_call_arg_value("commit_id")
 

--- a/examples/huggingface_unsafe_download.py
+++ b/examples/huggingface_unsafe_download.py
@@ -147,3 +147,18 @@ safe_snapshot_commit = snapshot_download(
     repo_id="org/model_name",
     revision="5d0f2e8a7f1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
 )
+
+
+# Example #24: Revision passed as a variable (can't be statically checked)
+MODEL_REVISION = "548fc3543a"
+safe_model_variable = AutoModel.from_pretrained(
+    "org/model_name",
+    revision=MODEL_REVISION
+)
+
+# Example #25: Revision from a dict/subscript access
+config = {"revision": "abc1234567"}
+safe_model_subscript = AutoModel.from_pretrained(
+    "org/model_name",
+    revision=config["revision"]
+)


### PR DESCRIPTION
Fixes #1345.

B615 incorrectly flagged calls like `AutoModel.from_pretrained(model_id, revision=MODEL_REVISION)` as unsafe. The issue is that `get_call_arg_value()` returns the variable name as a string for `ast.Name` nodes (e.g., `"MODEL_REVISION"`), which then fails the hex commit-hash check and triggers a false positive. For `ast.Subscript` nodes (e.g., `config["revision"]`), it returns `None`, which is indistinguishable from "no revision specified at all."

**Fix:** Before calling `get_call_arg_value()`, inspect the raw AST keywords. If a `revision` or `commit_id` keyword has a non-`ast.Constant` value (i.e., it's a variable, attribute access, subscript, function call, etc.), we give the user the benefit of the doubt and suppress the warning — since the value can't be statically analyzed.

**Test cases added:**
- Example #24: `revision=MODEL_REVISION` (variable) — no longer flagged
- Example #25: `revision=config["revision"]` (subscript) — no longer flagged