### PR TITLE
Fix B106 reporting wrong line number on multiline function calls

### DIFF
--- a/bandit/plugins/general_hardcoded_password.py
+++ b/bandit/plugins/general_hardcoded_password.py
@@ -15,12 +15,13 @@ RE_CANDIDATES = re.compile(
 )
 
 
-def _report(value):
+def _report(value, lineno=None):
     return bandit.Issue(
         severity=bandit.LOW,
         confidence=bandit.MEDIUM,
         cwe=issue.Cwe.HARD_CODED_PASSWORD,
         text=f"Possible hardcoded password: '{value}'",
+        lineno=lineno,
     )
 
 
@@ -201,7 +202,7 @@ def hardcoded_password_funcarg(context):
             and isinstance(kw.value.value, str)
             and RE_CANDIDATES.search(kw.arg)
         ):
-            return _report(kw.value.value)
+            return _report(kw.value.value, lineno=kw.value.lineno)
 
 
 @test.checks("FunctionDef")


### PR DESCRIPTION
## Summary

Fixes #1328.

B106 (`hardcoded_password_funcarg`) reported the line number of the `ast.Call` node rather than the line of the specific keyword argument containing the hardcoded password. For multiline function calls, this meant:

- The reported location pointed to the function call start, not the actual password
- `# nosec B106` placed on the correct line (with the password) was ineffective
- `# nosec B106` on the reported line (function call) silenced the warning but was misleading

### Fix

Pass `kw.value.lineno` to the `Issue` constructor so the reported location points to the actual hardcoded string, not the call.

### Before
```
>> Issue: [B106:hardcoded_password_funcarg] Possible hardcoded password: 'on_behalf_of'
   Location: ./auth.py:8:15    <-- line of dict( call
```

### After
```
>> Issue: [B106:hardcoded_password_funcarg] Possible hardcoded password: 'on_behalf_of'
   Location: ./auth.py:12:15   <-- line of requested_token_use="on_behalf_of"
```

## Test plan
- [x] Existing `test_hardcoded_passwords` functional test passes (issue counts unchanged)
- [x] Verified manually: before fix reports line 8, after fix reports line 12
- [x] Verified `# nosec B106` on the keyword line now works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)