### PR TITLE
Fix --exclude with bare directory names when scanning with -r .

### DIFF
--- a/bandit/core/manager.py
+++ b/bandit/core/manager.py
@@ -215,6 +215,7 @@ class BanditManager:
         # if there are command line provided exclusions add them to the list
         if excluded_paths:
             for path in excluded_paths.split(","):
+                path = os.path.normpath(path)
                 if os.path.isdir(path):
                     path = os.path.join(path, "*")
 
@@ -380,7 +381,7 @@ def _get_files_from_dir(
 
     for root, _, files in os.walk(files_dir):
         for filename in files:
-            path = os.path.join(root, filename)
+            path = os.path.normpath(os.path.join(root, filename))
             if _is_file_included(path, included_globs, excluded_path_strings):
                 files_list.add(path)
             else:
@@ -405,6 +406,10 @@ def _is_file_included(
     :param enforce_glob: Can set to false to bypass extension check
     :return: Boolean indicating whether a file should be included
     """
+    # Normalize the path to remove redundant separators and "./" prefixes,
+    # ensuring consistent matching against exclusion patterns (see #975).
+    path = os.path.normpath(path)
+
     return_value = False
 
     # if this is matches a glob of files we look at, and it isn't in an

--- a/tests/unit/core/test_manager.py
+++ b/tests/unit/core/test_manager.py
@@ -127,6 +127,29 @@ class ManagerTests(testtools.TestCase):
         self.assertEqual({"/a/c.ww"}, exc)
         self.assertEqual({"/a/a.py", "/a/b.py"}, inc)
 
+    @mock.patch("os.walk")
+    def test_get_files_from_dir_excludes_dot_prefixed_paths(self, os_walk):
+        """Test that exclusions work when os.walk yields ./-prefixed paths.
+
+        When scanning with files_dir=".", os.walk produces paths like
+        "./venv/file.py". Exclude patterns like "venv/*" must still match
+        these paths after normalization. See GitHub issue #975.
+        """
+        os_walk.return_value = [
+            (".", ("venv", "src"), ()),
+            ("./venv", (), ("bad.py",)),
+            ("./src", (), ("good.py",)),
+        ]
+
+        inc, exc = manager._get_files_from_dir(
+            files_dir=".",
+            included_globs=["*.py"],
+            excluded_path_strings=["venv/*"],
+        )
+
+        self.assertEqual({"src/good.py"}, inc)
+        self.assertEqual({"venv/bad.py"}, exc)
+
     def test_populate_baseline_success(self):
         # Test populate_baseline with valid JSON
         baseline_data = """{
@@ -271,6 +294,15 @@ class ManagerTests(testtools.TestCase):
         self.manager.discover_files(["./x/y/z.py"], True, "y")
         self.assertEqual([], self.manager.files_list)
         self.assertEqual(["./x/y/z.py"], self.manager.excluded_files)
+
+        # Test bare dir name when directory exists (GitHub issue #975).
+        # When the exclude path is a real directory, discover_files appends
+        # "/*" to it. After normpath, "venv" stays "venv" -> "venv/*",
+        # which correctly matches normalized walked paths like "venv/bad.py".
+        isdir.side_effect = [True, False]
+        self.manager.discover_files(["./venv/bad.py"], True, "venv")
+        self.assertEqual([], self.manager.files_list)
+        self.assertEqual(["./venv/bad.py"], self.manager.excluded_files)
 
     @mock.patch("os.path.isdir")
     def test_discover_files_exclude_cmdline(self, isdir):


### PR DESCRIPTION
## Summary
- Fixes `--exclude` flag silently failing when bare directory names (e.g., `venv` instead of `./venv`) are passed while scanning with `-r .`
- Root cause: `os.walk(".")` yields `./`-prefixed paths, but excluded dirs become glob patterns (e.g., `venv/*`) that don't match the `./`-prefixed paths in either `fnmatch` or substring checks
- Fix: apply `os.path.normpath()` to normalize paths consistently before comparison

## Test plan
- [x] Added `test_get_files_from_dir_excludes_dot_prefixed_paths` covering the os.walk ./-prefix scenario
- [x] Extended `test_discover_files_exclude_dir` with a case for bare dir names when the directory exists
- [x] All 262 existing tests pass
- [x] Manual verification: `bandit -r . --exclude excluded_dir` now correctly excludes the directory

Resolves #975
See also #966