### PR TITLE
Fix B104 false negative for empty-string wildcard bind

### DIFF
--- a/bandit/plugins/general_bind_all_interfaces.py
+++ b/bandit/plugins/general_bind_all_interfaces.py
@@ -43,7 +43,7 @@ from bandit.core import test_properties as test
 @test.checks("Str")
 @test.test_id("B104")
 def hardcoded_bind_all_interfaces(context):
-    if context.string_val == "0.0.0.0":  # nosec: B104
+    if context.string_val in ("0.0.0.0", ""):  # nosec: B104
         return bandit.Issue(
             severity=bandit.MEDIUM,
             confidence=bandit.MEDIUM,

--- a/examples/binding.py
+++ b/examples/binding.py
@@ -3,3 +3,4 @@ import socket
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 s.bind(('0.0.0.0', 31137))
 s.bind(('192.168.0.1', 8080))
+s.bind(("", 31137))


### PR DESCRIPTION
Fixes B104 to also detect empty string bind (e.g. `s.bind(('', port))`). Closes #1395.