### PR TITLE
Fix #nosec with test ID not counted in Total lines skipped

### DIFF
--- a/bandit/core/tester.py
+++ b/bandit/core/tester.py
@@ -81,7 +81,8 @@ class BanditTester:
                         # If the set is empty then it means that nosec was
                         # used without test number -> update nosecs counter.
                         # If the test id is in the set of tests to skip,
-                        # log and increment the skip by test count.
+                        # log and increment both the nosec and
+                        # skipped_tests counters.
                         if not nosec_tests_to_skip:
                             LOG.debug("skipped, nosec without test number")
                             self.metrics.note_nosec()
@@ -90,6 +91,7 @@ class BanditTester:
                             LOG.debug(
                                 f"skipped, nosec for test {result.test_id}"
                             )
+                            self.metrics.note_nosec()
                             self.metrics.note_skipped_test()
                             continue
 

--- a/bandit/formatters/html.py
+++ b/bandit/formatters/html.py
@@ -95,7 +95,8 @@ This formatter outputs the issues as HTML.
                 Metrics:<br>
             </div>
             Total lines of code: <span id="loc">9</span><br>
-            Total lines skipped (#nosec): <span id="nosec">0</span>
+            Total lines skipped (#nosec): <span id="nosec">0</span><br>
+            Total potential issues skipped due to specifically being disabled (e.g., #nosec BXXX): <span id="skipped_tests">0</span>
         </div>
     </div>
 
@@ -316,7 +317,8 @@ pre {
             Metrics:<br>
         </div>
         Total lines of code: <span id="loc">{loc}</span><br>
-        Total lines skipped (#nosec): <span id="nosec">{nosec}</span>
+        Total lines skipped (#nosec): <span id="nosec">{nosec}</span><br>
+        Total potential issues skipped due to specifically being disabled (e.g., #nosec BXXX): <span id="skipped_tests">{skipped_tests}</span>
     </div>
 </div>
 
@@ -378,6 +380,7 @@ pre {
     metrics_summary = metrics_block.format(
         loc=manager.metrics.data["_totals"]["loc"],
         nosec=manager.metrics.data["_totals"]["nosec"],
+        skipped_tests=manager.metrics.data["_totals"]["skipped_tests"],
     )
 
     # build the report and output it

--- a/bandit/formatters/screen.py
+++ b/bandit/formatters/screen.py
@@ -226,6 +226,11 @@ def report(manager, fileobj, sev_level, conf_level, lines=-1):
             "\tTotal lines skipped (#nosec): %i"
             % (manager.metrics.data["_totals"]["nosec"])
         )
+        bits.append(
+            "\tTotal potential issues skipped due to specifically being "
+            "disabled (e.g., #nosec BXXX): %i"
+            % (manager.metrics.data["_totals"]["skipped_tests"])
+        )
 
         bits.append(get_metrics(manager))
         skipped = manager.get_skipped()

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -428,7 +428,7 @@ class FunctionalTests(testtools.TestCase):
         example_file = "sql_multiline_statements.py"
         confidence_low_tests = 13
         severity_medium_tests = 26
-        nosec_tests = 7
+        nosec_tests = 15
         skipped_tests = 8
         expect = {
             "SEVERITY": {

--- a/tests/unit/formatters/test_html.py
+++ b/tests/unit/formatters/test_html.py
@@ -43,7 +43,7 @@ class HtmlFormatterTests(testtools.TestCase):
     @mock.patch("bandit.core.issue.Issue.get_code")
     @mock.patch("bandit.core.manager.BanditManager.get_issue_list")
     def test_report_contents(self, get_issue_list, get_code):
-        self.manager.metrics.data["_totals"] = {"loc": 1000, "nosec": 50}
+        self.manager.metrics.data["_totals"] = {"loc": 1000, "nosec": 50, "skipped_tests": 0}
 
         issue_a = _get_issue_instance(severity=bandit.LOW)
         issue_a.fname = "abc.py"
@@ -132,7 +132,7 @@ class HtmlFormatterTests(testtools.TestCase):
     @mock.patch("bandit.core.issue.Issue.get_code")
     @mock.patch("bandit.core.manager.BanditManager.get_issue_list")
     def test_escaping(self, get_issue_list, get_code):
-        self.manager.metrics.data["_totals"] = {"loc": 1000, "nosec": 50}
+        self.manager.metrics.data["_totals"] = {"loc": 1000, "nosec": 50, "skipped_tests": 0}
         marker = "<tag in code>"
 
         issue_a = _get_issue_instance()

--- a/tests/unit/formatters/test_html.py
+++ b/tests/unit/formatters/test_html.py
@@ -43,7 +43,11 @@ class HtmlFormatterTests(testtools.TestCase):
     @mock.patch("bandit.core.issue.Issue.get_code")
     @mock.patch("bandit.core.manager.BanditManager.get_issue_list")
     def test_report_contents(self, get_issue_list, get_code):
-        self.manager.metrics.data["_totals"] = {"loc": 1000, "nosec": 50, "skipped_tests": 0}
+        self.manager.metrics.data["_totals"] = {
+            "loc": 1000,
+            "nosec": 50,
+            "skipped_tests": 0,
+        }
 
         issue_a = _get_issue_instance(severity=bandit.LOW)
         issue_a.fname = "abc.py"
@@ -132,7 +136,11 @@ class HtmlFormatterTests(testtools.TestCase):
     @mock.patch("bandit.core.issue.Issue.get_code")
     @mock.patch("bandit.core.manager.BanditManager.get_issue_list")
     def test_escaping(self, get_issue_list, get_code):
-        self.manager.metrics.data["_totals"] = {"loc": 1000, "nosec": 50, "skipped_tests": 0}
+        self.manager.metrics.data["_totals"] = {
+            "loc": 1000,
+            "nosec": 50,
+            "skipped_tests": 0,
+        }
         marker = "<tag in code>"
 
         issue_a = _get_issue_instance()

--- a/tests/unit/formatters/test_screen.py
+++ b/tests/unit/formatters/test_screen.py
@@ -121,7 +121,11 @@ class ScreenFormatterTests(testtools.TestCase):
 
         get_issue_list.return_value = [issue_a, issue_b]
 
-        self.manager.metrics.data["_totals"] = {"loc": 1000, "nosec": 50, "skipped_tests": 0}
+        self.manager.metrics.data["_totals"] = {
+            "loc": 1000,
+            "nosec": 50,
+            "skipped_tests": 0,
+        }
         for category in ["SEVERITY", "CONFIDENCE"]:
             for level in ["UNDEFINED", "LOW", "MEDIUM", "HIGH"]:
                 self.manager.metrics.data["_totals"][f"{category}.{level}"] = 1

--- a/tests/unit/formatters/test_screen.py
+++ b/tests/unit/formatters/test_screen.py
@@ -121,7 +121,7 @@ class ScreenFormatterTests(testtools.TestCase):
 
         get_issue_list.return_value = [issue_a, issue_b]
 
-        self.manager.metrics.data["_totals"] = {"loc": 1000, "nosec": 50}
+        self.manager.metrics.data["_totals"] = {"loc": 1000, "nosec": 50, "skipped_tests": 0}
         for category in ["SEVERITY", "CONFIDENCE"]:
             for level in ["UNDEFINED", "LOW", "MEDIUM", "HIGH"]:
                 self.manager.metrics.data["_totals"][f"{category}.{level}"] = 1


### PR DESCRIPTION
## Problem

When a `# nosec` comment includes a specific test ID (e.g., `# nosec B608`), the line is not counted in the "Total lines skipped (#nosec)" metric. Only bare `# nosec` comments increment the nosec counter, while specific `# nosec BXXX` comments only increment the `skipped_tests` counter.

This means if your code uses `# nosec B608`, the output shows:
```
Total lines skipped (#nosec): 0
```
even though the line was explicitly skipped by a nosec comment.

## Fix

When a `# nosec` comment with a specific test ID is encountered, **both** `note_nosec()` and `note_skipped_test()` are now called. This accurately reflects that the line was skipped by a nosec comment, regardless of whether it was bare or specific.

The `skipped_tests` metric still tracks how many skips were test-specific, and the `nosec` metric now correctly counts all lines with any `#nosec` comment.

## Additional changes

- Added `skipped_tests` metric display to the **screen** and **HTML** formatters for consistency with the text formatter (partially addresses PR #1206)
- Updated unit and functional tests to match the new behavior

Resolves: #1205