### PR TITLE
fix: clamp severity/confidence index to prevent IndexError (closes #1423)

### DIFF
--- a/bandit/cli/main.py
+++ b/bandit/cli/main.py
@@ -677,7 +677,9 @@ def main():
     LOG.debug(b_mgr.metrics)
 
     # trigger output of results by Bandit Manager
-    sev_level = constants.RANKING[min(args.severity, len(constants.RANKING)) - 1]
+    sev_level = constants.RANKING[
+        min(args.severity, len(constants.RANKING)) - 1
+    ]
     conf_level = constants.RANKING[args.confidence - 1]
     b_mgr.output_results(
         args.context_lines,

--- a/bandit/cli/main.py
+++ b/bandit/cli/main.py
@@ -677,7 +677,7 @@ def main():
     LOG.debug(b_mgr.metrics)
 
     # trigger output of results by Bandit Manager
-    sev_level = constants.RANKING[args.severity - 1]
+    sev_level = constants.RANKING[min(args.severity, len(constants.RANKING)) - 1]
     conf_level = constants.RANKING[args.confidence - 1]
     b_mgr.output_results(
         args.context_lines,


### PR DESCRIPTION
## What
When `-ii -ll` is specified multiple times on the command line (e.g., `bandit -ii -ll -ii -ll`), `args.severity` and `args.confidence` accumulate counts beyond the valid index range of `constants.RANKING`, causing an `IndexError`.

## Fix
Clamp the severity and confidence values to the maximum valid index in `constants.RANKING` before using them as indices. This ensures that specifying `-i` or `-l` more times than there are ranking levels defaults to the highest level rather than raising an error.

Closes #1423