### PR TITLE
B202: detect tarfile extractall imported via a from-import

### DIFF
--- a/bandit/plugins/tarfile_unsafe_members.py
+++ b/bandit/plugins/tarfile_unsafe_members.py
@@ -46,7 +46,6 @@ unless you explicitly need them.
     Added check for filter parameter
 
 """
-
 import ast
 
 import bandit

--- a/bandit/plugins/tarfile_unsafe_members.py
+++ b/bandit/plugins/tarfile_unsafe_members.py
@@ -46,6 +46,7 @@ unless you explicitly need them.
     Added check for filter parameter
 
 """
+
 import ast
 
 import bandit
@@ -106,7 +107,7 @@ def is_filter_data(context):
 def tarfile_unsafe_members(context):
     if all(
         [
-            context.is_module_imported_exact("tarfile"),
+            context.is_module_imported_like("tarfile"),
             "extractall" in context.call_function_name,
         ]
     ):

--- a/examples/tarfile_extractall_from_import.py
+++ b/examples/tarfile_extractall_from_import.py
@@ -1,0 +1,16 @@
+# Regression example for issue #1171: B202 should still fire on extractall when
+# tarfile is brought in with a from-import (no bare "import tarfile").
+import tempfile
+from tarfile import TarFile
+
+
+def unsafe_from_import_handler(filename):
+    tar = TarFile(filename)
+    tar.extractall(path=tempfile.mkdtemp())
+    tar.close()
+
+
+def filter_data_from_import_handler(filename):
+    tar = TarFile(filename)
+    tar.extractall(path=tempfile.mkdtemp(), filter="data")
+    tar.close()

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -872,6 +872,14 @@ class FunctionalTests(testtools.TestCase):
         }
         self.check_example("tarfile_extractall.py", expect)
 
+    def test_tarfile_unsafe_members_from_import(self):
+        """B202 fires on extractall when tarfile is from-imported (#1171)."""
+        expect = {
+            "SEVERITY": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 1},
+            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 0, "HIGH": 1},
+        }
+        self.check_example("tarfile_extractall_from_import.py", expect)
+
     def test_pytorch_load(self):
         """Test insecure usage of torch.load."""
         expect = {


### PR DESCRIPTION
Fixes #1171.

B202 (`tarfile_unsafe_members`) only fired when the file had a bare `import tarfile`. If you instead write:

```python
from tarfile import TarFile
TarFile(path).extractall(dest)
```

nothing was reported - a false negative on a genuine path-traversal sink (CWE-22). The cause is the guard: `from tarfile import TarFile` registers the import as `tarfile.TarFile`, so `is_module_imported_exact("tarfile")` is False and the check is skipped.

The fix swaps that for `is_module_imported_like("tarfile")`, which is how most plugins resolve imports.

I checked it doesn't widen into false positives: `extractall` with `filter="data"` stays clean, and an unrelated `zipfile.ZipFile(...).extractall()` stays clean (the substring "tarfile" isn't in "zipfile.ZipFile"). Added a from-import example and a functional test for it; the full functional suite still passes.