### PR TITLE
fix(cli): clamp severity/confidence counts to valid ranking range

### DIFF
--- a/bandit/cli/main.py
+++ b/bandit/cli/main.py
@@ -20,6 +20,14 @@ BASE_CONFIG = "bandit.yaml"
 LOG = logging.getLogger()
 
 
+def _ranking_level(count):
+    """Return a ranking label for a CLI severity/confidence count."""
+    if count is None:
+        count = 1
+    index = min(max(count, 1), len(constants.RANKING)) - 1
+    return constants.RANKING[index]
+
+
 def _init_logger(log_level=logging.INFO, log_format=None):
     """Initialize the logger.
 
@@ -677,8 +685,8 @@ def main():
     LOG.debug(b_mgr.metrics)
 
     # trigger output of results by Bandit Manager
-    sev_level = constants.RANKING[args.severity - 1]
-    conf_level = constants.RANKING[args.confidence - 1]
+    sev_level = _ranking_level(args.severity)
+    conf_level = _ranking_level(args.confidence)
     b_mgr.output_results(
         args.context_lines,
         sev_level,

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -175,6 +175,31 @@ class BanditCLIMainTests(testtools.TestCase):
             bandit._log_option_source(None, None, None, option_name)
         )
 
+    def test_ranking_level_clamps_excess_counts(self):
+        self.assertEqual("HIGH", bandit._ranking_level(4))
+        self.assertEqual("HIGH", bandit._ranking_level(5))
+        self.assertEqual("HIGH", bandit._ranking_level(100))
+
+    def test_ranking_level_handles_none(self):
+        self.assertEqual("UNDEFINED", bandit._ranking_level(None))
+
+    @mock.patch(
+        "sys.argv",
+        ["bandit", "-c", "bandit.yaml", "-ii", "-ll", "-ii", "-ll", "test.py"],
+    )
+    def test_main_repeated_severity_confidence_flags(self):
+        temp_directory = self.useFixture(fixtures.TempDir()).path
+        os.chdir(temp_directory)
+        with open("bandit.yaml", "w") as fd:
+            fd.write(bandit_config_content)
+        with open("test.py", "w") as fd:
+            fd.write("")
+        with mock.patch(
+            "bandit.core.manager.BanditManager.results_count"
+        ) as mock_mgr_results_ct:
+            mock_mgr_results_ct.return_value = 0
+            self.assertRaisesRegex(SystemExit, "0", bandit.main)
+
     @mock.patch("sys.argv", ["bandit", "-c", "bandit.yaml", "test"])
     def test_main_config_unopenable(self):
         # Test that bandit exits when a config file cannot be opened


### PR DESCRIPTION
## Summary
- Clamp repeated severity and confidence CLI counts to the valid ranking index range
- Add regression tests for excess counts and repeated flags

Fixes #1423

## Test plan
- Ran unit tests for the new regression cases
- Manual repro: bandit -ii -ll -ii -ll empty.py exits 0

Made with [Cursor](https://cursor.com)