### PR TITLE
Detect requests.request() calls without a timeout in B113

### DIFF
--- a/bandit/plugins/request_without_timeout.py
+++ b/bandit/plugins/request_without_timeout.py
@@ -56,10 +56,11 @@ from bandit.core import test_properties as test
 @test.test_id("B113")
 def request_without_timeout(context):
     HTTP_VERBS = {"get", "options", "head", "post", "put", "patch", "delete"}
+    REQUESTS_ATTRS = {"request"} | HTTP_VERBS
     HTTPX_ATTRS = {"request", "stream", "Client", "AsyncClient"} | HTTP_VERBS
     qualname = context.call_function_name_qual.split(".")[0]
 
-    if qualname == "requests" and context.call_function_name in HTTP_VERBS:
+    if qualname == "requests" and context.call_function_name in REQUESTS_ATTRS:
         # check for missing timeout
         if context.check_call_arg_value("timeout") is None:
             return bandit.Issue(
@@ -70,7 +71,7 @@ def request_without_timeout(context):
             )
     if (
         qualname == "requests"
-        and context.call_function_name in HTTP_VERBS
+        and context.call_function_name in REQUESTS_ATTRS
         or qualname == "httpx"
         and context.call_function_name in HTTPX_ATTRS
     ):

--- a/examples/requests-missing-timeout.py
+++ b/examples/requests-missing-timeout.py
@@ -17,6 +17,8 @@ requests.options('https://gmail.com')
 requests.options('https://gmail.com', timeout=None)
 requests.head('https://gmail.com')
 requests.head('https://gmail.com', timeout=None)
+requests.request('GET', 'https://gmail.com')
+requests.request('GET', 'https://gmail.com', timeout=None)
 httpx.get('https://gmail.com')
 httpx.get('https://gmail.com', timeout=None)
 httpx.post('https://gmail.com')
@@ -46,6 +48,7 @@ async with httpx.AsyncClient(timeout=None) as client:
 
 # Okay
 not_requests.get('https://gmail.com')
+requests.request('GET', 'https://gmail.com', timeout=5)
 requests.get('https://gmail.com', timeout=5)
 requests.post('https://gmail.com', timeout=5)
 requests.put('https://gmail.com', timeout=5)

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -381,8 +381,8 @@ class FunctionalTests(testtools.TestCase):
     def test_requests_without_timeout(self):
         """Test for the `requests` library missing timeouts."""
         expect = {
-            "SEVERITY": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 25, "HIGH": 0},
-            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 25, "MEDIUM": 0, "HIGH": 0},
+            "SEVERITY": {"UNDEFINED": 0, "LOW": 0, "MEDIUM": 27, "HIGH": 0},
+            "CONFIDENCE": {"UNDEFINED": 0, "LOW": 27, "MEDIUM": 0, "HIGH": 0},
         }
         self.check_example("requests-missing-timeout.py", expect)
 


### PR DESCRIPTION
I work on supply-chain security tooling and was reading the B113 plugin.

B113 flags `requests` calls that are missing a timeout, but it only looks at the named verb helpers (get, post, put, and so on). It never checks `requests.request(method, url, ...)`, which is the generic entry point those helpers all wrap and which also has no default timeout. So both of these are missed today:

```python
requests.request('GET', url)                 # missing timeout
requests.request('GET', url, timeout=None)   # timeout disabled
```

The httpx side of the same plugin already includes `"request"` in its set, so `httpx.request(..., timeout=None)` is caught while the requests equivalent is not. This lines the two up.

The change is small: add a `REQUESTS_ATTRS` set (the verbs plus `"request"`) and use it for the two requests branches. httpx behavior is unchanged. I extended `examples/requests-missing-timeout.py` with the two new error cases plus a `timeout=5` okay case, and bumped the expected counts in the functional test (25 to 27). The functional suite passes locally.
